### PR TITLE
HTS-24 : Probable fix for  "Absolute URLs not allowed" error during successful 2-factor redirect

### DIFF
--- a/app/uk/gov/hmrc/helptosavefrontend/auth/HTSCompositePageVisibilityPredicate.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/auth/HTSCompositePageVisibilityPredicate.scala
@@ -30,12 +30,12 @@ object HTSCompositePageVisibilityPredicate extends CompositePageVisibilityPredic
   //TODO: not sure how to make of this(UpliftingIdentityConfidencePredicate)
   private val ivUpliftURI: URI =
     new URI(s"${ivUpliftUrl}?origin=$sosOrigin&" +
-      s"completionURL=${URLEncoder.encode(redirectUrlAfterAuth, "UTF-8")}&" +
+      s"completionURL=${URLEncoder.encode(loginCallbackURL, "UTF-8")}&" +
       s"failureURL=${URLEncoder.encode(perTaxIdentityCheckFailedUrl, "UTF-8")}" +
       s"&confidenceLevel=200")
 
   private val twoFactorURI: URI =
     new URI(s"${twoFactorUrl}?" +
-      s"continue=${URLEncoder.encode(redirectUrlAfterAuth, "UTF-8")}&" +
+      s"continue=${URLEncoder.encode(loginCallbackURL, "UTF-8")}&" +
       s"failure=${URLEncoder.encode(perTaxIdentityCheckFailedUrl, "UTF-8")}")
 }

--- a/app/uk/gov/hmrc/helptosavefrontend/auth/HelpToSaveAuthenticationProvider.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/auth/HelpToSaveAuthenticationProvider.scala
@@ -29,7 +29,7 @@ object HelpToSaveAuthenticationProvider extends GovernmentGateway {
 
   override def redirectToLogin(implicit request: Request[_]): Future[FailureResult] = ggRedirect
 
-  override def continueURL: String = redirectUrlAfterAuth
+  override def continueURL: String = loginCallbackURL
 
   override def loginURL: String = companySignInUrl
 

--- a/app/uk/gov/hmrc/helptosavefrontend/config/frontendAppConfig.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/config/frontendAppConfig.scala
@@ -33,9 +33,7 @@ object FrontendAppConfig extends AppConfig with ServicesConfig {
   private val contactHost = configuration.getString(s"contact-frontend.host").getOrElse("")
   private val contactFormServiceIdentifier = "MyService"
 
-  private val logInContinueURL = getConfString("auth.login-callback.base-url", "")
-  private val loginURL = getConfString("auth.login-callback.path", "")
-  val redirectUrlAfterAuth = logInContinueURL + loginURL
+  val loginCallbackURL = getConfString("login-callback.url", "")
 
   private val companyAuthFrontend = getConfString("company-auth.url", throw new RuntimeException("Company auth url required"))
   private val companyAuthSignInPath = getConfString("company-auth.sign-in-path", "")

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -53,11 +53,14 @@ microservice {
     }
 
     services {
+
       auth {
         host = localhost
         port = 8500
-        login-callback.base-url = "http://localhost:7000"
-        login-callback.path= "/help-to-save/declaration"
+      }
+
+      login-callback {
+        url = "http://localhost:7000/help-to-save/declaration"
       }
 
       company-auth {


### PR DESCRIPTION
On QA env, I see the following error during 2 factor auth 

```https://www-qa.tax.service.gov.uk/coafe/two-step-verification/registration/success?continue=https://www-qa.tax.service.gov.uk/help-to-save/declaration&origin=unknown``` 
gives 
```Absolute URLs not allowed```
