### PR TITLE
refactor: upgraded frontend assests version to 2.246.0

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -218,7 +218,7 @@ google-analytics {
 }
 
 assets {
-  version = "2.245.0"
+  version = "2.246.0"
   version = ${?ASSETS_FRONTEND_VERSION}
   url = "http://localhost:9032/assets/"
 }


### PR DESCRIPTION
Fixed bug described here https://github.com/hmrc/assets-frontend/issues/782.

After pulling the fix you will need to restart Assets Frontend by the following command` sm --restart ASSETS_FRONTEND -r 2.246.0
`