### PR TITLE
No implicit Audit required for communication between micro-services

### DIFF
--- a/app/uk/gov/hmrc/helptosavefrontend/config/FrontendWiring.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/config/FrontendWiring.scala
@@ -54,7 +54,7 @@ trait WSHttp
 @Singleton
 class WSHttpExtension extends WSHttp with HttpAuditing with ServicesConfig {
 
-  override val hooks: Seq[HttpHook] = Seq(AuditingHook)
+  override val hooks: Seq[HttpHook] = NoneRequired
 
   override def auditConnector: AuditConnector = FrontendAuditConnector
 
@@ -94,7 +94,7 @@ class FrontendAuthConnector @Inject() (wsHttp: WSHttp) extends PlayAuthConnector
 class WSHttpProxy extends WSPost with WSProxy with RunMode with HttpAuditing with ServicesConfig {
   override lazy val appName: String = getString("appName")
   override lazy val wsProxyServer: Option[WSProxyServer] = WSProxyConfiguration("proxy")
-  override val hooks: Seq[HttpHook] = Seq(AuditingHook)
+  override val hooks: Seq[HttpHook] = NoneRequired
   override lazy val auditConnector: AuditConnector = FrontendAuditConnector
 
   /**


### PR DESCRIPTION
```
Graeme Blackwood [9:14 AM] 
@suresh.mandalapu we have only ever told teams to turn off auditing of assets like CSS and JS. Or implicit auditing between microservices.
All end user client - server requests for pages (as opposed to assets) must be audited
This should happen automatically with the play-auditing library
```