### PR TITLE
neatened up HTTP verb usage

### DIFF
--- a/app/uk/gov/hmrc/helptosavefrontend/config/FrontendWiring.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/config/FrontendWiring.scala
@@ -17,8 +17,7 @@
 package uk.gov.hmrc.helptosavefrontend.config
 
 import com.google.inject.{ImplementedBy, Inject, Singleton}
-import play.api.http.HttpVerbs.{GET ⇒ GET_VERB, POST ⇒ POST_VERB, PUT ⇒ PUT_VERB}
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.Writes
 import play.api.libs.ws.WSProxyServer
 import uk.gov.hmrc.auth.core.PlayAuthConnector
 import uk.gov.hmrc.http._
@@ -29,12 +28,16 @@ import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.config.{AppName, RunMode, ServicesConfig}
 import uk.gov.hmrc.play.frontend.config.LoadAuditingConfig
 import uk.gov.hmrc.play.http.ws._
-import scala.concurrent.ExecutionContext.Implicits.global
+import uk.gov.hmrc.helptosavefrontend.util.HeaderCarrierOps._
 
 import scala.concurrent.{ExecutionContext, Future}
 
 object FrontendAuditConnector extends AuditConnector with AppName {
   override lazy val auditingConfig: AuditingConfig = LoadAuditingConfig("auditing")
+}
+
+class RawHttpReads extends HttpReads[HttpResponse] {
+  override def read(method: String, url: String, response: HttpResponse): HttpResponse = response
 }
 
 @ImplementedBy(classOf[WSHttpExtension])
@@ -44,17 +47,19 @@ trait WSHttp
   with HttpPut with WSPut
   with HttpDelete with WSDelete {
 
-  def get(url: String)(implicit rhc: HeaderCarrier): Future[HttpResponse]
+  def get(url: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse]
 
   def post[A](url:     String,
               body:    A,
               headers: Seq[(String, String)] = Seq.empty[(String, String)]
-  )(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse]
+  )(implicit w: Writes[A], hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse]
 
 }
 
 @Singleton
 class WSHttpExtension extends WSHttp with HttpAuditing with ServicesConfig {
+
+  val httpReads: HttpReads[HttpResponse] = new RawHttpReads
 
   override val hooks: Seq[HttpHook] = NoneRequired
 
@@ -62,15 +67,13 @@ class WSHttpExtension extends WSHttp with HttpAuditing with ServicesConfig {
 
   override def appName: String = getString("appName")
 
+  override def mapErrors(httpMethod: String, url: String, f: Future[HttpResponse])(implicit ec: ExecutionContext): Future[HttpResponse] = f
+
   /**
    * Returns a [[Future[HttpResponse]] without throwing exceptions if the status us not `2xx`. Needed
    * to replace [[GET]] method provided by the hmrc library which will throw exceptions in such cases.
    */
-  def get(url: String)(implicit rhc: HeaderCarrier): Future[HttpResponse] = withTracing(GET_VERB, url) {
-    val httpResponse = doGet(url)
-    executeHooks(url, GET_VERB, None, httpResponse)
-    httpResponse
-  }
+  def get(url: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = super.GET(url)(httpReads, hc, ec)
 
   /**
    * Returns a [[Future[HttpResponse]] without throwing exceptions if the status us not `2xx`. Needed
@@ -79,11 +82,7 @@ class WSHttpExtension extends WSHttp with HttpAuditing with ServicesConfig {
   def post[A](url:     String,
               body:    A,
               headers: Seq[(String, String)] = Seq.empty[(String, String)]
-  )(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse] = withTracing(POST_VERB, url) {
-    val httpResponse = doPost(url, body, headers)
-    executeHooks(url, POST_VERB, None, httpResponse)
-    httpResponse
-  }
+  )(implicit w: Writes[A], hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = super.POST(url, body)(w, httpReads, hc, ec)
 }
 
 @Singleton
@@ -101,10 +100,15 @@ class WSHttpProxy
   with HttpAuditing
   with ServicesConfig
   with HttpHooks {
+
+  val httpReads: HttpReads[HttpResponse] = new RawHttpReads
+
   override lazy val appName: String = getString("appName")
   override lazy val wsProxyServer: Option[WSProxyServer] = WSProxyConfiguration("proxy")
   override val hooks: Seq[HttpHook] = Seq(AuditingHook)
   override lazy val auditConnector: AuditConnector = FrontendAuditConnector
+
+  override def mapErrors(httpMethod: String, url: String, f: Future[HttpResponse])(implicit ec: ExecutionContext): Future[HttpResponse] = f
 
   /**
    * Returns a [[Future[HttpResponse]] without throwing exceptions if the status us not `2xx`. Needed
@@ -113,11 +117,8 @@ class WSHttpProxy
   def post[A](url:     String,
               body:    A,
               headers: Map[String, String] = Map.empty[String, String]
-  )(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse] = {
-    val httpResponse = doPost(url, body, headers.toSeq)
-    executeHooks(url, POST_VERB, None, httpResponse)
-    httpResponse
-  }
+  )(implicit w: Writes[A], hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
+    super.POST(url, body)(w, httpReads, hc.withExtraHeaders(headers), ec)
 
   /**
    * Returns a [[Future[HttpResponse]] without throwing exceptions if the status us not `2xx`. Needed
@@ -126,10 +127,7 @@ class WSHttpProxy
   def put[A](url:     String,
              body:    A,
              headers: Map[String, String] = Map.empty[String, String]
-  )(implicit rds: Writes[A], hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
-    // cannot use `doPut` over here because it doesn't allow for headers
-    val httpResponse = buildRequest(url).withHeaders(headers.toList: _*).put(Json.toJson(body)).map(new WSHttpResponse(_))
-    executeHooks(url, PUT_VERB, None, httpResponse)
-    httpResponse
-  }
+  )(implicit w: Writes[A], hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
+    super.PUT(url, body)(w, httpReads, hc.withExtraHeaders(headers), ec)
+
 }

--- a/app/uk/gov/hmrc/helptosavefrontend/util/HeaderCarrierOps.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/util/HeaderCarrierOps.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helptosavefrontend.util
+
+import uk.gov.hmrc.http.HeaderCarrier
+
+object HeaderCarrierOps {
+
+  implicit class HeaderCarrierOps(val hc: HeaderCarrier) extends AnyVal {
+    def withExtraHeaders(headers: Map[String, String]): HeaderCarrier =
+      hc.copy(extraHeaders = hc.extraHeaders ++ headers.toSeq)
+  }
+
+}

--- a/test/uk/gov/hmrc/helptosavefrontend/connectors/EmailVerificationConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/connectors/EmailVerificationConnectorSpec.scala
@@ -30,7 +30,7 @@ import uk.gov.hmrc.play.config.ServicesConfig
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.test.UnitSpec
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class EmailVerificationConnectorSpec extends UnitSpec with TestSupport with ServicesConfig with GeneratorDrivenPropertyChecks {
 
@@ -66,27 +66,27 @@ class EmailVerificationConnectorSpec extends UnitSpec with TestSupport with Serv
 
   def mockPost[A](expectedBody: A)(returnedStatus: Int, returnedData: Option[JsValue]): Unit = {
     val verifyEmailURL = s"$emailVerifyBaseURL/email-verification/verification-requests"
-    (mockHttp.post(_: String, _: A, _: Seq[(String, String)])(_: Writes[A], _: HeaderCarrier))
-      .expects(verifyEmailURL, expectedBody, Seq.empty[(String, String)], *, *)
+    (mockHttp.post(_: String, _: A, _: Seq[(String, String)])(_: Writes[A], _: HeaderCarrier, _: ExecutionContext))
+      .expects(verifyEmailURL, expectedBody, Seq.empty[(String, String)], *, *, *)
       .returning(Future.successful(HttpResponse(returnedStatus, returnedData)))
   }
 
   def mockPostFailure[A](expectedBody: A): Unit = {
     val verifyEmailURL = s"$emailVerifyBaseURL/email-verification/verification-requests"
-    (mockHttp.post(_: String, _: A, _: Seq[(String, String)])(_: Writes[A], _: HeaderCarrier))
-      .expects(verifyEmailURL, expectedBody, Seq.empty[(String, String)], *, *)
+    (mockHttp.post(_: String, _: A, _: Seq[(String, String)])(_: Writes[A], _: HeaderCarrier, _: ExecutionContext))
+      .expects(verifyEmailURL, expectedBody, Seq.empty[(String, String)], *, *, *)
       .returning(Future.failed(new Exception("Oh no!")))
   }
 
   def mockGet(returnedStatus: Int, email: String, returnedData: Option[JsValue]): Unit = {
     val verifyEmailURL = s"$emailVerifyBaseURL/email-verification/verified-email-addresses/$email"
-    (mockHttp.get(_: String)(_: HeaderCarrier)).expects(verifyEmailURL, *)
+    (mockHttp.get(_: String)(_: HeaderCarrier, _: ExecutionContext)).expects(verifyEmailURL, *, *)
       .returning(Future.successful(HttpResponse(returnedStatus, returnedData)))
   }
 
   def mockGetFailure(): Unit = {
     val verifyEmailURL = s"$emailVerifyBaseURL/email-verification/verified-email-addresses/$email"
-    (mockHttp.get(_: String)(_: HeaderCarrier)).expects(verifyEmailURL, *)
+    (mockHttp.get(_: String)(_: HeaderCarrier, _: ExecutionContext)).expects(verifyEmailURL, *, *)
       .returning(Future.failed(new Exception("Uh oh!")))
   }
 

--- a/test/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveConnectorSpec.scala
@@ -30,7 +30,7 @@ import uk.gov.hmrc.helptosavefrontend.connectors.HelpToSaveConnectorImpl.{Eligib
 import uk.gov.hmrc.helptosavefrontend.models._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 // scalastyle:off magic.number
 class HelpToSaveConnectorSpec extends TestSupport with GeneratorDrivenPropertyChecks {
@@ -42,8 +42,8 @@ class HelpToSaveConnectorSpec extends TestSupport with GeneratorDrivenPropertyCh
   lazy val connector: HelpToSaveConnector = new HelpToSaveConnectorImpl(mockHttp)
 
   def mockHttpGet[I](url: String)(result: Option[HttpResponse]): Unit =
-    (mockHttp.get(_: String)(_: HeaderCarrier))
-      .expects(url, *)
+    (mockHttp.get(_: String)(_: HeaderCarrier, _: ExecutionContext))
+      .expects(url, *, *)
       .returning(result.fold(
         Future.failed[HttpResponse](new Exception("")))(Future.successful))
 

--- a/test/uk/gov/hmrc/helptosavefrontend/connectors/NSIConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/connectors/NSIConnectorSpec.scala
@@ -27,7 +27,6 @@ import uk.gov.hmrc.helptosavefrontend.config.FrontendAppConfig.{nsiAuthHeaderKey
 import uk.gov.hmrc.helptosavefrontend.config.WSHttpProxy
 import uk.gov.hmrc.helptosavefrontend.connectors.NSIConnector.{SubmissionFailure, SubmissionSuccess}
 import uk.gov.hmrc.helptosavefrontend.models._
-import uk.gov.hmrc.helptosavefrontend.util.NINO
 import uk.gov.hmrc.http.logging.Authorization
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
@@ -46,8 +45,8 @@ class NSIConnectorSpec extends TestSupport with MockFactory with GeneratorDriven
   implicit val hc: HeaderCarrier = HeaderCarrier(authorization = Some(Authorization("auth")))
 
   def mockCreateAccount[I](body: I, url: String)(result: Either[String, HttpResponse]): Unit = {
-    (mockHTTPProxy.post(_: String, _: I, _: Map[String, String])(_: Writes[I], _: HeaderCarrier))
-      .expects(url, body, Map(nsiAuthHeaderKey → nsiBasicAuth), *, *)
+    (mockHTTPProxy.post(_: String, _: I, _: Map[String, String])(_: Writes[I], _: HeaderCarrier, _: ExecutionContext))
+      .expects(url, body, Map(nsiAuthHeaderKey → nsiBasicAuth), *, *, *)
       .returning(
         result.fold(
           e ⇒ Future.failed(new Exception(e)),


### PR DESCRIPTION
We have custom logic on top of `http-verbs` to avoid having to handle their library throwing exceptions. For the `GET` method the exceptions were being thrown here:

https://github.com/hmrc/http-verbs/blob/master/src/main/scala/uk/gov/hmrc/http/HttpGet.scala#L32

Here, instead of copying and pasting the code there without the exception throwing stuff I've overriden the `mapErrors` function to do nothing and implemented a custom `HttpReads` to do nothing 