### PR TITLE
hts-528 fix email verication copy break on long emails

### DIFF
--- a/app/uk/gov/hmrc/helptosavefrontend/views/register/email_updated.scala.html
+++ b/app/uk/gov/hmrc/helptosavefrontend/views/register/email_updated.scala.html
@@ -23,9 +23,9 @@
 
 @uk.gov.hmrc.helptosavefrontend.views.html.main_template(title = Messages("hts.email-updated.page-title"), bodyClasses = None) {
 
- <div class="transaction-banner--complete">
-  <h1 class="transaction-banner__heading">@messages("hts.email-updated.title")</h1>
-  <p>@email</p>
+ <div class="govuk-box-highlight">
+    <h1 class="heading-xlarge">@messages("hts.email-updated.title")</h1>
+    <p>@email</p>
  </div>
 
  <p>@messages("hts.email-updated.p1")</p>


### PR DESCRIPTION
Long email addresses were breaking - extending outside the container due to the font size - so I have updated the markup used to fix this issue.