### PR TITLE
SSL debug logging :  verbose = true

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -74,7 +74,7 @@ play.ws.ssl {
     sslctx = false
     defaultctx = false
     handshake = true
-    verbose = false
+    verbose = true
     data = false
     keymanager = false
     trustmanager = false


### PR DESCRIPTION
```hmm, just checked on QA, no ssl logs, i remember it worked last time with enabling only `handshake = true` , we can try with setting `verbose = true`  too , but remember these are not recommended on production```