### PR TITLE
HTS-1254:  pass bank details to NS&I

### DIFF
--- a/app/uk/gov/hmrc/helptosavefrontend/config/FrontendAppConfig.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/config/FrontendAppConfig.scala
@@ -32,6 +32,10 @@ class FrontendAppConfig @Inject() (override val runModeConfiguration: Configurat
 
   val appName: String = getString("appName")
 
+  val version: String = getString("microservice.services.nsi.version")
+
+  val systemId: String = getString("microservice.services.nsi.systemId")
+
   private def getUrlFor(service: String) = getString(s"microservice.services.$service.url")
 
   val authUrl: String = baseUrl("auth")

--- a/app/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveConnector.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveConnector.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.helptosavefrontend.models._
 import uk.gov.hmrc.helptosavefrontend.models.account.Account
 import uk.gov.hmrc.helptosavefrontend.models.eligibility.{EligibilityCheckResponse, EligibilityCheckResult}
 import uk.gov.hmrc.helptosavefrontend.models.register.CreateAccountRequest
-import uk.gov.hmrc.helptosavefrontend.models.userinfo.{MissingUserInfo, NSIUserInfo}
+import uk.gov.hmrc.helptosavefrontend.models.userinfo.{MissingUserInfo, NSIPayload}
 import uk.gov.hmrc.helptosavefrontend.util.HttpResponseOps._
 import uk.gov.hmrc.helptosavefrontend.util.{Email, Result, base64Encode, maskNino}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
@@ -55,7 +55,7 @@ trait HelpToSaveConnector {
 
   def createAccount(createAccountRequest: CreateAccountRequest)(implicit hc: HeaderCarrier, ex: ExecutionContext): Future[HttpResponse]
 
-  def updateEmail(userInfo: NSIUserInfo)(implicit hc: HeaderCarrier, ex: ExecutionContext): Future[HttpResponse]
+  def updateEmail(userInfo: NSIPayload)(implicit hc: HeaderCarrier, ex: ExecutionContext): Future[HttpResponse]
 
 }
 
@@ -169,7 +169,7 @@ class HelpToSaveConnectorImpl @Inject() (http: WSHttp)(implicit frontendAppConfi
   override def createAccount(createAccountRequest: CreateAccountRequest)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
     http.post(createAccountURL, createAccountRequest)
 
-  override def updateEmail(userInfo: NSIUserInfo)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
+  override def updateEmail(userInfo: NSIPayload)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
     http.put(updateEmailURL, userInfo)
 }
 

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/AccountHolderController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/AccountHolderController.scala
@@ -92,10 +92,9 @@ class AccountHolderController @Inject() (val helpToSaveService:          HelpToS
                       logger.warn(s"Could not write pending email to session cache: $e")
                       SeeOther(routes.EmailController.verifyEmailErrorTryLater().url)
                     }.merge
-                case Left(e) ⇒ {
+                case Left(e) ⇒
                   logger.warn(s"Given email address failed validation, errors: $e")
                   SeeOther(routes.AccountHolderController.getUpdateYourEmailAddress().url)
-                }
               }
           ),
           routes.AccountHolderController.getUpdateYourEmailAddress().url
@@ -198,7 +197,7 @@ class AccountHolderController @Inject() (val helpToSaveService:          HelpToS
 
         case Right(userInfo) ⇒
           val result: EitherT[Future, UpdateEmailError, Unit] = for {
-            _ ← helpToSaveService.updateEmail(NSIPayload(userInfo, emailVerificationParams.email)).leftMap(UpdateEmailError.NSIError)
+            _ ← helpToSaveService.updateEmail(NSIPayload(userInfo, emailVerificationParams.email, frontendAppConfig.version, frontendAppConfig.systemId)).leftMap(UpdateEmailError.NSIError)
             _ ← helpToSaveService.storeConfirmedEmail(emailVerificationParams.email).leftMap(UpdateEmailError.EmailMongoError)
             _ ← sessionCacheConnector.put(HTSSession(None, Some(emailVerificationParams.email), None))
               .leftMap[UpdateEmailError](UpdateEmailError.SessionCacheError)

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/AccountHolderController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/AccountHolderController.scala
@@ -34,7 +34,7 @@ import uk.gov.hmrc.helptosavefrontend.connectors.{EmailVerificationConnector, Se
 import uk.gov.hmrc.helptosavefrontend.forms.{EmailValidation, UpdateEmail, UpdateEmailForm}
 import uk.gov.hmrc.helptosavefrontend.metrics.Metrics
 import uk.gov.hmrc.helptosavefrontend.models._
-import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIUserInfo
+import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIPayload
 import uk.gov.hmrc.helptosavefrontend.services.HelpToSaveService
 import uk.gov.hmrc.helptosavefrontend.util.Logging._
 import uk.gov.hmrc.helptosavefrontend.util.{Crypto, Email, EmailVerificationParams, NINOLogMessageTransformer, toFuture}
@@ -198,7 +198,7 @@ class AccountHolderController @Inject() (val helpToSaveService:          HelpToS
 
         case Right(userInfo) ⇒
           val result: EitherT[Future, UpdateEmailError, Unit] = for {
-            _ ← helpToSaveService.updateEmail(NSIUserInfo(userInfo, emailVerificationParams.email)).leftMap(UpdateEmailError.NSIError)
+            _ ← helpToSaveService.updateEmail(NSIPayload(userInfo, emailVerificationParams.email)).leftMap(UpdateEmailError.NSIError)
             _ ← helpToSaveService.storeConfirmedEmail(emailVerificationParams.email).leftMap(UpdateEmailError.EmailMongoError)
             _ ← sessionCacheConnector.put(HTSSession(None, Some(emailVerificationParams.email), None))
               .leftMap[UpdateEmailError](UpdateEmailError.SessionCacheError)

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/EmailController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/EmailController.scala
@@ -274,7 +274,7 @@ class EmailController @Inject() (val helpToSaveService:          HelpToSaveServi
                 userInfo ⇒ {
                   val result = for {
                     e ← decryptedEmailEither
-                    _ ← helpToSaveService.updateEmail(NSIPayload(userInfo.copy(email = Some(e)), e))
+                    _ ← helpToSaveService.updateEmail(NSIPayload(userInfo.copy(email = Some(e)), e, frontendAppConfig.version, frontendAppConfig.systemId))
                     r ← EitherT.liftF(toFuture(SeeOther(frontendAppConfig.nsiManageAccountUrl)))
                     _ ← {
                       val auditEvent = EmailChanged(htsContext.nino, "", e, duringRegistrationJourney = false, routes.EmailController.confirmEmail(email).url)
@@ -367,7 +367,7 @@ class EmailController @Inject() (val helpToSaveService:          HelpToSaveServi
           emailVerificationParams,
           params ⇒ {
             for {
-              _ ← helpToSaveService.updateEmail(NSIPayload(userInfo.copy(email = Some(params.email)), params.email))
+              _ ← helpToSaveService.updateEmail(NSIPayload(userInfo.copy(email = Some(params.email)), params.email, frontendAppConfig.version, frontendAppConfig.systemId))
               _ ← helpToSaveService.storeConfirmedEmail(params.email)
               r ← EitherT.liftF(updateSessionAndReturnResult(
                 HTSSession(None, Some(params.email), None),

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/EmailController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/EmailController.scala
@@ -36,7 +36,7 @@ import uk.gov.hmrc.helptosavefrontend.forms._
 import uk.gov.hmrc.helptosavefrontend.metrics.Metrics
 import uk.gov.hmrc.helptosavefrontend.models.HTSSession.EligibleWithUserInfo
 import uk.gov.hmrc.helptosavefrontend.models.eligibility.EligibilityCheckResult.{AlreadyHasAccount, Eligible, Ineligible}
-import uk.gov.hmrc.helptosavefrontend.models.userinfo.{NSIUserInfo, UserInfo}
+import uk.gov.hmrc.helptosavefrontend.models.userinfo.{NSIPayload, UserInfo}
 import uk.gov.hmrc.helptosavefrontend.models._
 import uk.gov.hmrc.helptosavefrontend.services.HelpToSaveService
 import uk.gov.hmrc.helptosavefrontend.util.Logging.LoggerOps
@@ -274,7 +274,7 @@ class EmailController @Inject() (val helpToSaveService:          HelpToSaveServi
                 userInfo ⇒ {
                   val result = for {
                     e ← decryptedEmailEither
-                    _ ← helpToSaveService.updateEmail(NSIUserInfo(userInfo.copy(email = Some(e)), e))
+                    _ ← helpToSaveService.updateEmail(NSIPayload(userInfo.copy(email = Some(e)), e))
                     r ← EitherT.liftF(toFuture(SeeOther(frontendAppConfig.nsiManageAccountUrl)))
                     _ ← {
                       val auditEvent = EmailChanged(htsContext.nino, "", e, duringRegistrationJourney = false, routes.EmailController.confirmEmail(email).url)
@@ -367,7 +367,7 @@ class EmailController @Inject() (val helpToSaveService:          HelpToSaveServi
           emailVerificationParams,
           params ⇒ {
             for {
-              _ ← helpToSaveService.updateEmail(NSIUserInfo(userInfo.copy(email = Some(params.email)), params.email))
+              _ ← helpToSaveService.updateEmail(NSIPayload(userInfo.copy(email = Some(params.email)), params.email))
               _ ← helpToSaveService.storeConfirmedEmail(params.email)
               r ← EitherT.liftF(updateSessionAndReturnResult(
                 HTSSession(None, Some(params.email), None),

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/RegisterController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/RegisterController.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.helptosavefrontend.models._
 import uk.gov.hmrc.helptosavefrontend.models.eligibility.EligibilityCheckResult.Eligible
 import uk.gov.hmrc.helptosavefrontend.models.eligibility.EligibilityReason
 import uk.gov.hmrc.helptosavefrontend.models.register.CreateAccountRequest
-import uk.gov.hmrc.helptosavefrontend.models.userinfo.{NSIUserInfo, UserInfo}
+import uk.gov.hmrc.helptosavefrontend.models.userinfo.{NSIPayload, UserInfo}
 import uk.gov.hmrc.helptosavefrontend.services.HelpToSaveService
 import uk.gov.hmrc.helptosavefrontend.services.HelpToSaveServiceImpl.SubmissionFailure
 import uk.gov.hmrc.helptosavefrontend.util.Logging._
@@ -93,7 +93,7 @@ class RegisterController @Inject() (val helpToSaveService:     HelpToSaveService
     val nino = htsContext.nino
     checkIfAlreadyEnrolled { () ⇒
       checkIfDoneEligibilityChecks { eligibleWithEmail ⇒
-        val userInfo = NSIUserInfo(eligibleWithEmail.userInfo, eligibleWithEmail.confirmedEmail)
+        val userInfo = NSIPayload(eligibleWithEmail.userInfo, eligibleWithEmail.confirmedEmail)
         val createAccountRequest = CreateAccountRequest(userInfo, eligibleWithEmail.eligible.value.reasonCode)
         helpToSaveService.createAccount(createAccountRequest).fold[Result]({ e ⇒
           logger.warn(s"Error while trying to create account: ${submissionFailureToString(e)}", nino)

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/RegisterController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/RegisterController.scala
@@ -96,10 +96,8 @@ class RegisterController @Inject() (val helpToSaveService:     HelpToSaveService
         eligibleWithEmail.bankDetails match {
           case Some(bankDetails) ⇒
             val payload =
-              NSIPayload(eligibleWithEmail.userInfo, eligibleWithEmail.confirmedEmail)
+              NSIPayload(eligibleWithEmail.userInfo, eligibleWithEmail.confirmedEmail, frontendAppConfig.version, frontendAppConfig.systemId)
                 .copy(nbaDetails = Some(bankDetails))
-                .copy(version = Some(frontendAppConfig.version))
-                .copy(systemId = Some(frontendAppConfig.systemId))
 
             val createAccountRequest = CreateAccountRequest(payload, eligibleWithEmail.eligible.value.reasonCode)
             helpToSaveService.createAccount(createAccountRequest).fold[Result]({ e ⇒
@@ -109,9 +107,9 @@ class RegisterController @Inject() (val helpToSaveService:     HelpToSaveService
               submissionSuccess ⇒ submissionSuccess.accountNumber.fold(
                 SeeOther(frontendAppConfig.nsiManageAccountUrl)
               ) {
-                acNumber ⇒
-                  Ok(views.html.register.account_created(acNumber.accountNumber))
-              }
+                  acNumber ⇒
+                    Ok(views.html.register.account_created(acNumber.accountNumber))
+                }
             )
 
           case None ⇒

--- a/app/uk/gov/hmrc/helptosavefrontend/models/register/CreateAccountRequest.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/models/register/CreateAccountRequest.scala
@@ -17,9 +17,9 @@
 package uk.gov.hmrc.helptosavefrontend.models.register
 
 import play.api.libs.json.{Format, Json}
-import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIUserInfo
+import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIPayload
 
-case class CreateAccountRequest(userInfo: NSIUserInfo, eligibilityReason: Int, source: String = "Digital")
+case class CreateAccountRequest(userInfo: NSIPayload, eligibilityReason: Int, source: String = "Digital")
 
 object CreateAccountRequest {
   implicit val createAccountRequestFormat: Format[CreateAccountRequest] = Json.format[CreateAccountRequest]

--- a/app/uk/gov/hmrc/helptosavefrontend/models/register/CreateAccountRequest.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/models/register/CreateAccountRequest.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.helptosavefrontend.models.register
 import play.api.libs.json.{Format, Json}
 import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIPayload
 
-case class CreateAccountRequest(userInfo: NSIPayload, eligibilityReason: Int, source: String = "Digital")
+case class CreateAccountRequest(payload: NSIPayload, eligibilityReason: Int, source: String = "Digital")
 
 object CreateAccountRequest {
   implicit val createAccountRequestFormat: Format[CreateAccountRequest] = Json.format[CreateAccountRequest]

--- a/app/uk/gov/hmrc/helptosavefrontend/models/userinfo/NSIPayload.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/models/userinfo/NSIPayload.scala
@@ -22,22 +22,26 @@ import java.time.format.DateTimeFormatter
 import cats.instances.string._
 import cats.syntax.eq._
 import play.api.libs.json._
-import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIUserInfo.ContactDetails
+import uk.gov.hmrc.helptosavefrontend.forms.BankDetails
+import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIPayload.ContactDetails
 
 import scala.util.{Failure, Success, Try}
 
-case class NSIUserInfo(forename:            String,
-                       surname:             String,
-                       dateOfBirth:         LocalDate,
-                       nino:                String,
-                       contactDetails:      ContactDetails,
-                       registrationChannel: String         = "online")
+case class NSIPayload(forename:            String,
+                      surname:             String,
+                      dateOfBirth:         LocalDate,
+                      nino:                String,
+                      contactDetails:      ContactDetails,
+                      registrationChannel: String              = "online",
+                      nbaDetails:          Option[BankDetails] = None,
+                      version:             Option[String]      = None,
+                      systemId:            Option[String]      = None)
 
-object NSIUserInfo {
+object NSIPayload {
 
-  implicit class NSIUserInfoOps(val nsiUserInfo: NSIUserInfo) {
-    def updateEmail(newEmail: String): NSIUserInfo =
-      nsiUserInfo.copy(contactDetails = nsiUserInfo.contactDetails.copy(email = newEmail))
+  implicit class NSIPayloadOps(val nsiPayload: NSIPayload) {
+    def updateEmail(newEmail: String): NSIPayload =
+      nsiPayload.copy(contactDetails = nsiPayload.contactDetails.copy(email = newEmail))
   }
 
   case class ContactDetails(address1:                String,
@@ -59,10 +63,10 @@ object NSIUserInfo {
   }
 
   /**
-   * Performs validation checks on the given [[UserInfo]] and converts to [[NSIUserInfo]]
+   * Performs validation checks on the given [[UserInfo]] and converts to [[NSIPayload]]
    * if successful.
    */
-  def apply(userInfo: UserInfo, email: String): NSIUserInfo = {
+  def apply(userInfo: UserInfo, email: String): NSIPayload = {
       def extractContactDetails(userInfo: UserInfo): ContactDetails = {
         val (line1, line2, line3, line4, line5) =
           userInfo.address.lines.map(_.cleanupSpecialCharacters).filter(_.nonEmpty) match {
@@ -83,7 +87,7 @@ object NSIUserInfo {
         )
       }
 
-    NSIUserInfo(
+    NSIPayload(
       userInfo.forename.cleanupSpecialCharacters,
       userInfo.surname.cleanupSpecialCharacters,
       userInfo.dateOfBirth,
@@ -109,6 +113,6 @@ object NSIUserInfo {
 
   implicit val contactDetailsFormat: Format[ContactDetails] = Json.format[ContactDetails]
 
-  implicit val nsiUserInfoFormat: Format[NSIUserInfo] = Json.format[NSIUserInfo]
+  implicit val nsiPayloadFormat: Format[NSIPayload] = Json.format[NSIPayload]
 
 }

--- a/app/uk/gov/hmrc/helptosavefrontend/models/userinfo/NSIPayload.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/models/userinfo/NSIPayload.scala
@@ -34,8 +34,8 @@ case class NSIPayload(forename:            String,
                       contactDetails:      ContactDetails,
                       registrationChannel: String              = "online",
                       nbaDetails:          Option[BankDetails] = None,
-                      version:             Option[String]      = None,
-                      systemId:            Option[String]      = None)
+                      version:             String,
+                      systemId:            String)
 
 object NSIPayload {
 
@@ -66,7 +66,7 @@ object NSIPayload {
    * Performs validation checks on the given [[UserInfo]] and converts to [[NSIPayload]]
    * if successful.
    */
-  def apply(userInfo: UserInfo, email: String): NSIPayload = {
+  def apply(userInfo: UserInfo, email: String, version: String, systemId: String): NSIPayload = {
       def extractContactDetails(userInfo: UserInfo): ContactDetails = {
         val (line1, line2, line3, line4, line5) =
           userInfo.address.lines.map(_.cleanupSpecialCharacters).filter(_.nonEmpty) match {
@@ -92,7 +92,11 @@ object NSIPayload {
       userInfo.surname.cleanupSpecialCharacters,
       userInfo.dateOfBirth,
       userInfo.nino.cleanupSpecialCharacters.removeAllSpaces,
-      extractContactDetails(userInfo)
+      extractContactDetails(userInfo),
+      "online",
+      None,
+      version,
+      systemId
     )
   }
 

--- a/app/uk/gov/hmrc/helptosavefrontend/services/HelpToSaveService.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/services/HelpToSaveService.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.helptosavefrontend.models._
 import uk.gov.hmrc.helptosavefrontend.models.account.{Account, AccountNumber}
 import uk.gov.hmrc.helptosavefrontend.models.eligibility.EligibilityCheckResult
 import uk.gov.hmrc.helptosavefrontend.models.register.CreateAccountRequest
-import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIUserInfo
+import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIPayload
 import uk.gov.hmrc.helptosavefrontend.services.HelpToSaveServiceImpl.{SubmissionFailure, SubmissionSuccess}
 import uk.gov.hmrc.helptosavefrontend.util.HttpResponseOps._
 import uk.gov.hmrc.helptosavefrontend.util.{Email, Logging, Result, maskNino}
@@ -38,6 +38,8 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @ImplementedBy(classOf[HelpToSaveServiceImpl])
 trait HelpToSaveService {
+
+  type CreateAccountResultType = EitherT[Future, SubmissionFailure, SubmissionSuccess]
 
   def getUserEnrolmentStatus()(implicit hc: HeaderCarrier, ec: ExecutionContext): Result[EnrolmentStatus]
 
@@ -49,13 +51,13 @@ trait HelpToSaveService {
 
   def getConfirmedEmail()(implicit hv: HeaderCarrier, ec: ExecutionContext): Result[Option[String]]
 
-  def createAccount(createAccountRequest: CreateAccountRequest)(implicit hc: HeaderCarrier, ec: ExecutionContext): EitherT[Future, SubmissionFailure, SubmissionSuccess]
+  def createAccount(createAccountRequest: CreateAccountRequest)(implicit hc: HeaderCarrier, ec: ExecutionContext): CreateAccountResultType
 
   def isAccountCreationAllowed()(implicit hc: HeaderCarrier, ec: ExecutionContext): Result[UserCapResponse]
 
   def getAccount(nino: String, correlationId: UUID)(implicit hc: HeaderCarrier, ec: ExecutionContext): Result[Account]
 
-  def updateEmail(userInfo: NSIUserInfo)(implicit hc: HeaderCarrier, ec: ExecutionContext): Result[Unit]
+  def updateEmail(userInfo: NSIPayload)(implicit hc: HeaderCarrier, ec: ExecutionContext): Result[Unit]
 
 }
 
@@ -77,9 +79,7 @@ class HelpToSaveServiceImpl @Inject() (helpToSaveConnector: HelpToSaveConnector)
   def getConfirmedEmail()(implicit hc: HeaderCarrier, ec: ExecutionContext): Result[Option[String]] =
     helpToSaveConnector.getEmail()
 
-  def createAccount(createAccountRequest: CreateAccountRequest)(implicit hc: HeaderCarrier,
-                                                                ec: ExecutionContext
-  ): EitherT[Future, SubmissionFailure, SubmissionSuccess] =
+  def createAccount(createAccountRequest: CreateAccountRequest)(implicit hc: HeaderCarrier, ec: ExecutionContext): CreateAccountResultType =
     EitherT(helpToSaveConnector.createAccount(createAccountRequest)
       .map[Either[SubmissionFailure, SubmissionSuccess]] { response ⇒
 
@@ -108,7 +108,7 @@ class HelpToSaveServiceImpl @Inject() (helpToSaveConnector: HelpToSaveConnector)
   def getAccount(nino: String, correlationId: UUID)(implicit hc: HeaderCarrier, ec: ExecutionContext): Result[Account] =
     helpToSaveConnector.getAccount(nino, correlationId)
 
-  override def updateEmail(userInfo: NSIUserInfo)(implicit hc: HeaderCarrier, ec: ExecutionContext): Result[Unit] =
+  override def updateEmail(userInfo: NSIPayload)(implicit hc: HeaderCarrier, ec: ExecutionContext): Result[Unit] =
     EitherT(helpToSaveConnector.updateEmail(userInfo).map[Either[String, Unit]] { response ⇒
 
       response.status match {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -153,6 +153,8 @@ microservice {
       host = localhost
       port = 7005
       manage-account.url = "https://nsandi.com"
+      version = "V2.0"
+      systemId = "MDTP REGISTRATION"
     }
 
   }

--- a/test/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveConnectorSpec.scala
@@ -28,7 +28,7 @@ import play.api.libs.json._
 import uk.gov.hmrc.helptosavefrontend.TestSupport
 import uk.gov.hmrc.helptosavefrontend.config.WSHttp
 import uk.gov.hmrc.helptosavefrontend.connectors.HelpToSaveConnectorImpl.GetEmailResponse
-import uk.gov.hmrc.helptosavefrontend.models.TestData.UserData.validNSIUserInfo
+import uk.gov.hmrc.helptosavefrontend.models.TestData.UserData.validNSIPayload
 import uk.gov.hmrc.helptosavefrontend.models._
 import uk.gov.hmrc.helptosavefrontend.models.account.{Account, AccountNumber, Blocking}
 import uk.gov.hmrc.helptosavefrontend.models.eligibility.EligibilityCheckResponse
@@ -364,8 +364,8 @@ class HelpToSaveConnectorSpec extends TestSupport with GeneratorDrivenPropertyCh
     "creating account" must {
 
       "return http response as it is to the caller" in {
-        val request = CreateAccountRequest(validNSIUserInfo, 7)
         val response = HttpResponse(201, Some(Json.toJson(SubmissionSuccess(Some(AccountNumber("1234567890123"))))))
+        val request = CreateAccountRequest(validNSIPayload, 7)
         mockHttpPost(createAccountURL, request)(Some(response))
         await(connector.createAccount(request)) shouldBe response
       }
@@ -375,8 +375,8 @@ class HelpToSaveConnectorSpec extends TestSupport with GeneratorDrivenPropertyCh
 
       "return http response as it is to the caller" in {
         val response = HttpResponse(200, Some(Json.toJson(())))
-        mockHttpPut(updateEmailURL, validNSIUserInfo)(Some(response))
-        await(connector.updateEmail(validNSIUserInfo)) shouldBe response
+        mockHttpPut(updateEmailURL, validNSIPayload)(Some(response))
+        await(connector.updateEmail(validNSIPayload)) shouldBe response
       }
     }
 

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/AccountHolderControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/AccountHolderControllerSpec.scala
@@ -34,7 +34,7 @@ import uk.gov.hmrc.helptosavefrontend.models._
 import uk.gov.hmrc.helptosavefrontend.models.account.{Account, Blocking}
 import uk.gov.hmrc.helptosavefrontend.models.email.VerifyEmailError
 import uk.gov.hmrc.helptosavefrontend.models.email.VerifyEmailError.{AlreadyVerified, OtherError}
-import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIUserInfo
+import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIPayload
 import uk.gov.hmrc.helptosavefrontend.services.HelpToSaveService
 import uk.gov.hmrc.helptosavefrontend.util.{Email, EmailVerificationParams, NINO}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -98,8 +98,8 @@ class AccountHolderControllerSpec extends AuthSupport with CSRFSupport with Sess
       .expects(nino, email, firstName, false, *, *)
       .returning(Future.successful(result))
 
-  def mockUpdateEmailWithNSI(userInfo: NSIUserInfo)(result: Either[String, Unit]): Unit =
-    (mockHelpToSaveService.updateEmail(_: NSIUserInfo)(_: HeaderCarrier, _: ExecutionContext))
+  def mockUpdateEmailWithNSI(userInfo: NSIPayload)(result: Either[String, Unit]): Unit =
+    (mockHelpToSaveService.updateEmail(_: NSIPayload)(_: HeaderCarrier, _: ExecutionContext))
       .expects(userInfo, *, *)
       .returning(EitherT.fromEither[Future](result))
 
@@ -255,7 +255,7 @@ class AccountHolderControllerSpec extends AuthSupport with CSRFSupport with Sess
             mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(mockedRetrievals)
             mockEnrolmentCheck()(Right(Enrolled(true)))
             mockEmailGet()(Right(Some("email")))
-            mockUpdateEmailWithNSI(nsiUserInfo.updateEmail(verifiedEmail))(Right(()))
+            mockUpdateEmailWithNSI(nsiPayload.updateEmail(verifiedEmail))(Right(()))
             mockStoreEmail(verifiedEmail)(Right(()))
             mockSessionCacheConnectorPut(HTSSession(None, Some(verifiedEmail), None))(Right(()))
             mockAuditEmailChanged(nino, "email", verifiedEmail,
@@ -277,7 +277,7 @@ class AccountHolderControllerSpec extends AuthSupport with CSRFSupport with Sess
               mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(mockedRetrievals)
               mockEnrolmentCheck()(Right(Enrolled(true)))
               mockEmailGet()(Right(Some("email")))
-              mockUpdateEmailWithNSI(nsiUserInfo.updateEmail(verifiedEmail))(Right(()))
+              mockUpdateEmailWithNSI(nsiPayload.updateEmail(verifiedEmail))(Right(()))
               mockStoreEmail(verifiedEmail)(Left(""))
               mockAuditEmailChanged(nino, "email", verifiedEmail,
                                     routes.AccountHolderController.emailVerifiedCallback(encodedParams).url)
@@ -330,7 +330,7 @@ class AccountHolderControllerSpec extends AuthSupport with CSRFSupport with Sess
             mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(mockedRetrievals)
             mockEnrolmentCheck()(Right(Enrolled(true)))
             mockEmailGet()(Right(Some("email")))
-            mockUpdateEmailWithNSI(nsiUserInfo.updateEmail(verifiedEmail))(Left(""))
+            mockUpdateEmailWithNSI(nsiPayload.updateEmail(verifiedEmail))(Left(""))
           }
 
           val result = verifyEmail(emailVerificationParams.encode())
@@ -344,7 +344,7 @@ class AccountHolderControllerSpec extends AuthSupport with CSRFSupport with Sess
             mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(mockedRetrievals)
             mockEnrolmentCheck()(Right(Enrolled(true)))
             mockEmailGet()(Right(Some("email")))
-            mockUpdateEmailWithNSI(nsiUserInfo.updateEmail(verifiedEmail))(Right(()))
+            mockUpdateEmailWithNSI(nsiPayload.updateEmail(verifiedEmail))(Right(()))
             mockStoreEmail(verifiedEmail)(Right(()))
             mockSessionCacheConnectorPut(HTSSession(None, Some(verifiedEmail), None))(Left(""))
             mockAuditEmailChanged(nino, "email", verifiedEmail,

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/AuthSupport.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/AuthSupport.scala
@@ -72,7 +72,7 @@ trait AuthSupport extends TestSupport {
   val nsiPayload = NSIPayload(
     firstName, lastName, toJavaDate(dob), nino, ContactDetails(
     line1, line2, Some(line3), None, None, postCode, Some(countryCode), emailStr
-  )
+  ), "online", None, "V2.0", "MDTP REGISTRATION"
   )
   val mockedNINORetrieval: Option[String] = Some(nino)
 

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/AuthSupport.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/AuthSupport.scala
@@ -23,8 +23,8 @@ import uk.gov.hmrc.auth.core.authorise._
 import uk.gov.hmrc.auth.core.retrieve._
 import uk.gov.hmrc.helptosavefrontend.TestSupport
 import uk.gov.hmrc.helptosavefrontend.models.HtsAuth.UserInfoRetrievals
-import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIUserInfo
-import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIUserInfo.ContactDetails
+import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIPayload
+import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIPayload.ContactDetails
 import uk.gov.hmrc.helptosavefrontend.util.toJavaDate
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -69,7 +69,7 @@ trait AuthSupport extends TestSupport {
   val countryCode = "GB"
   val itmpAddress = ItmpAddress(Some(line1), Some(line2), Some(line3), None, None, Some(postCode), Some(countryCode), Some(countryCode))
 
-  val nsiUserInfo = NSIUserInfo(
+  val nsiPayload = NSIPayload(
     firstName, lastName, toJavaDate(dob), nino, ContactDetails(
     line1, line2, Some(line3), None, None, postCode, Some(countryCode), emailStr
   )

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/EmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/EmailControllerSpec.scala
@@ -121,6 +121,9 @@ class EmailControllerSpec
 
   "The EmailController" when {
 
+    val version = appConfig.version
+    val systemId = appConfig.systemId
+
     val testEmail = "email@gmail.com"
 
     "handling getSelectEmailPage requests" must {
@@ -738,7 +741,7 @@ class EmailControllerSpec
           mockGetConfirmedEmail()(Right(None))
           mockSessionCacheConnectorPut(HTSSession(None, Some("decrypted"), None))(Right(None))
           mockStoreConfirmedEmail("decrypted")(Right(None))
-          mockUpdateEmail(NSIPayload(userInfo.userInfo.copy(email = Some("decrypted")), "decrypted"))(Right(None))
+          mockUpdateEmail(NSIPayload(userInfo.userInfo.copy(email = Some("decrypted")), "decrypted", version, systemId))(Right(None))
           mockAudit(EmailChanged(nino, "", "decrypted", false, routes.EmailController.confirmEmail(encryptedEmail).url))
         }
 
@@ -886,7 +889,7 @@ class EmailControllerSpec
 
       "handle DE users and update email successfully with NS&I" in {
 
-        val updatedNSIPayload = NSIPayload(validUserInfo.copy(email = Some(email)), email)
+        val updatedNSIPayload = NSIPayload(validUserInfo.copy(email = Some(email)), email, version, systemId)
         inSequence {
           mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(mockedRetrievals)
           mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
@@ -905,7 +908,7 @@ class EmailControllerSpec
 
       "handle DE users and handle errors during updating email with NS&I" in {
 
-        val updatedNSIUserInfo = NSIPayload(validUserInfo.copy(email = Some(email)), email)
+        val updatedNSIUserInfo = NSIPayload(validUserInfo.copy(email = Some(email)), email, version, systemId)
         inSequence {
           mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(mockedRetrievals)
           mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/RegisterControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/RegisterControllerSpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.helptosavefrontend.config.FrontendAppConfig
 import uk.gov.hmrc.helptosavefrontend.forms.BankDetails
 import uk.gov.hmrc.helptosavefrontend.models.HtsAuth.{AuthProvider, AuthWithCL200}
 import uk.gov.hmrc.helptosavefrontend.models.TestData.Eligibility._
-import uk.gov.hmrc.helptosavefrontend.models.TestData.UserData.{validNSIUserInfo, validUserInfo}
+import uk.gov.hmrc.helptosavefrontend.models.TestData.UserData.{validNSIPayload, validUserInfo}
 import uk.gov.hmrc.helptosavefrontend.models._
 import uk.gov.hmrc.helptosavefrontend.models.account.AccountNumber
 import uk.gov.hmrc.helptosavefrontend.models.eligibility.EligibilityCheckResult.Eligible
@@ -194,7 +194,7 @@ class RegisterControllerSpec
       "retrieve the user info from session cache and indicate to the user that the creation was successful " +
         "and enrol the user if the creation was successful" in {
           val userInfo = randomEligibleWithUserInfo(validUserInfo)
-          val createAccountRequest = CreateAccountRequest(validNSIUserInfo.updateEmail(confirmedEmail), userInfo.eligible.value.reasonCode)
+          val createAccountRequest = CreateAccountRequest(validNSIPayload.updateEmail(confirmedEmail), userInfo.eligible.value.reasonCode)
           inSequence {
             mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
             mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
@@ -210,7 +210,7 @@ class RegisterControllerSpec
       "indicate to the user that account creation was successful " +
         "even if the user couldn't be enrolled into hts at this time" in {
           val userInfo = randomEligibleWithUserInfo(validUserInfo)
-          val createAccountRequest = CreateAccountRequest(validNSIUserInfo.updateEmail(confirmedEmail), userInfo.eligible.value.reasonCode)
+          val createAccountRequest = CreateAccountRequest(validNSIPayload.updateEmail(confirmedEmail), userInfo.eligible.value.reasonCode)
           inSequence {
             mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
             mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
@@ -225,7 +225,7 @@ class RegisterControllerSpec
 
       "not update user counts but enrol the user if the user already had an account" in {
         val userInfo = randomEligibleWithUserInfo(validUserInfo)
-        val createAccountRequest = CreateAccountRequest(validNSIUserInfo.updateEmail(confirmedEmail), userInfo.eligible.value.reasonCode)
+        val createAccountRequest = CreateAccountRequest(validNSIPayload.updateEmail(confirmedEmail), userInfo.eligible.value.reasonCode)
         inSequence {
           mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
           mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
@@ -270,7 +270,7 @@ class RegisterControllerSpec
 
         "the help to save service returns with an error" in {
           val userInfo = randomEligibleWithUserInfo(validUserInfo)
-          val createAccountRequest = CreateAccountRequest(validNSIUserInfo.updateEmail(confirmedEmail), userInfo.eligible.value.reasonCode)
+          val createAccountRequest = CreateAccountRequest(validNSIPayload.updateEmail(confirmedEmail), userInfo.eligible.value.reasonCode)
           inSequence {
             mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
             mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/RegisterControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/RegisterControllerSpec.scala
@@ -184,6 +184,14 @@ class RegisterControllerSpec
 
     "creating an account" must {
       val confirmedEmail = "confirmed"
+      val bankDetails = BankDetails("1", "1", None, "name")
+      val userInfo = randomEligibleWithUserInfo(validUserInfo)
+      val payload = validNSIPayload.updateEmail(confirmedEmail)
+        .copy(nbaDetails = Some(bankDetails))
+        .copy(version = Some("V2.0"))
+        .copy(systemId = Some("MDTP REGISTRATION"))
+
+      val createAccountRequest = CreateAccountRequest(payload, userInfo.eligible.value.reasonCode)
 
         def doCreateAccountRequest(): Future[PlayResult] = controller.createAccount(fakeRequestWithCSRFToken)
 
@@ -193,12 +201,10 @@ class RegisterControllerSpec
 
       "retrieve the user info from session cache and indicate to the user that the creation was successful " +
         "and enrol the user if the creation was successful" in {
-          val userInfo = randomEligibleWithUserInfo(validUserInfo)
-          val createAccountRequest = CreateAccountRequest(validNSIPayload.updateEmail(confirmedEmail), userInfo.eligible.value.reasonCode)
           inSequence {
             mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
             mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
-            mockSessionCacheConnectorGet(Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None))))
+            mockSessionCacheConnectorGet(Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None, None, None, Some(bankDetails)))))
             mockCreateAccount(createAccountRequest)()
           }
 
@@ -209,12 +215,10 @@ class RegisterControllerSpec
 
       "indicate to the user that account creation was successful " +
         "even if the user couldn't be enrolled into hts at this time" in {
-          val userInfo = randomEligibleWithUserInfo(validUserInfo)
-          val createAccountRequest = CreateAccountRequest(validNSIPayload.updateEmail(confirmedEmail), userInfo.eligible.value.reasonCode)
           inSequence {
             mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
             mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
-            mockSessionCacheConnectorGet(Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None))))
+            mockSessionCacheConnectorGet(Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None, None, None, Some(bankDetails)))))
             mockCreateAccount(createAccountRequest)()
           }
 
@@ -224,12 +228,10 @@ class RegisterControllerSpec
         }
 
       "not update user counts but enrol the user if the user already had an account" in {
-        val userInfo = randomEligibleWithUserInfo(validUserInfo)
-        val createAccountRequest = CreateAccountRequest(validNSIPayload.updateEmail(confirmedEmail), userInfo.eligible.value.reasonCode)
         inSequence {
           mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
           mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
-          mockSessionCacheConnectorGet(Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None))))
+          mockSessionCacheConnectorGet(Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None, None, None, Some(bankDetails)))))
           mockCreateAccount(createAccountRequest)(Right(SubmissionSuccess(None)))
         }
 
@@ -240,7 +242,7 @@ class RegisterControllerSpec
 
       "redirect the user to nsi when they already have an account" in {
         val userInfo = randomEligibleWithUserInfo(validUserInfo)
-        val createAccountRequest = CreateAccountRequest(validNSIUserInfo.updateEmail(confirmedEmail), userInfo.eligible.value.reasonCode)
+        val createAccountRequest = CreateAccountRequest(validNSIPayload.updateEmail(confirmedEmail), userInfo.eligible.value.reasonCode)
         inSequence {
           mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
           mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
@@ -266,41 +268,47 @@ class RegisterControllerSpec
         redirectLocation(result) shouldBe Some(routes.EmailController.getSelectEmailPage().url)
       }
 
-      "redirect to the create account error page" when {
-
-        "the help to save service returns with an error" in {
-          val userInfo = randomEligibleWithUserInfo(validUserInfo)
-          val createAccountRequest = CreateAccountRequest(validNSIPayload.updateEmail(confirmedEmail), userInfo.eligible.value.reasonCode)
-          inSequence {
-            mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
-            mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
-            mockSessionCacheConnectorGet(Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None))))
-            mockCreateAccount(createAccountRequest)(Left(SubmissionFailure(None, "Uh oh", "Uh oh")))
-          }
-
-          val result = doCreateAccountRequest()
-          status(result) shouldBe SEE_OTHER
-          redirectLocation(result) shouldBe Some(routes.RegisterController.getCreateAccountErrorPage().url)
+      "redirect user to bank_details page if the session doesn't contain bank details" in {
+        inSequence {
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
+          mockSessionCacheConnectorGet(Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None))))
         }
+
+        val result = doCreateAccountRequest()
+        status(result) shouldBe SEE_OTHER
+        redirectLocation(result) shouldBe Some(routes.BankAccountController.getBankDetailsPage().url)
       }
 
-      "handling getCreateAccountErrorPage" must {
-
-          def doRequest(): Future[PlayResult] = controller.getCreateAccountErrorPage(FakeRequest())
-
-        behave like commonEnrolmentAndSessionBehaviour(doRequest)
-
-        "show the error page" in {
-          inSequence {
-            mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
-            mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
-            mockSessionCacheConnectorGet(Right(Some(HTSSession(Some(Right(randomEligibleWithUserInfo(validUserInfo))), Some(confirmedEmail), None))))
-          }
-
-          val result = doRequest()
-          contentAsString(result) should include("We could not create a Help to Save account for you at this time")
-
+      "redirect to the create account error page the help to save service returns with an error" in {
+        inSequence {
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
+          mockSessionCacheConnectorGet(Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None, None, None, Some(bankDetails)))))
+          mockCreateAccount(createAccountRequest)(Left(SubmissionFailure(None, "Uh oh", "Uh oh")))
         }
+
+        val result = doCreateAccountRequest()
+        status(result) shouldBe SEE_OTHER
+        redirectLocation(result) shouldBe Some(routes.RegisterController.getCreateAccountErrorPage().url)
+      }
+    }
+
+    "handling getCreateAccountErrorPage" must {
+      val confirmedEmail = "confirmed"
+        def doRequest(): Future[PlayResult] = controller.getCreateAccountErrorPage(FakeRequest())
+
+      behave like commonEnrolmentAndSessionBehaviour(doRequest)
+
+      "show the error page" in {
+        inSequence {
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
+          mockSessionCacheConnectorGet(Right(Some(HTSSession(Some(Right(randomEligibleWithUserInfo(validUserInfo))), Some(confirmedEmail), None))))
+        }
+
+        val result = doRequest()
+        contentAsString(result) should include("We could not create a Help to Save account for you at this time")
 
       }
     }

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/RegisterControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/RegisterControllerSpec.scala
@@ -188,8 +188,8 @@ class RegisterControllerSpec
       val userInfo = randomEligibleWithUserInfo(validUserInfo)
       val payload = validNSIPayload.updateEmail(confirmedEmail)
         .copy(nbaDetails = Some(bankDetails))
-        .copy(version = Some("V2.0"))
-        .copy(systemId = Some("MDTP REGISTRATION"))
+        .copy(version = "V2.0")
+        .copy(systemId = "MDTP REGISTRATION")
 
       val createAccountRequest = CreateAccountRequest(payload, userInfo.eligible.value.reasonCode)
 
@@ -241,12 +241,10 @@ class RegisterControllerSpec
       }
 
       "redirect the user to nsi when they already have an account" in {
-        val userInfo = randomEligibleWithUserInfo(validUserInfo)
-        val createAccountRequest = CreateAccountRequest(validNSIPayload.updateEmail(confirmedEmail), userInfo.eligible.value.reasonCode)
         inSequence {
           mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
           mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
-          mockSessionCacheConnectorGet(Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None))))
+          mockSessionCacheConnectorGet(Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None, None, None, Some(bankDetails)))))
           mockCreateAccount(createAccountRequest)(Right(SubmissionSuccess(None)))
         }
 

--- a/test/uk/gov/hmrc/helptosavefrontend/models/HTSEventSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/models/HTSEventSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.helptosavefrontend.models
 
 import uk.gov.hmrc.helptosavefrontend.TestSupport
-import uk.gov.hmrc.helptosavefrontend.models.TestData.UserData.validNSIUserInfo
+import uk.gov.hmrc.helptosavefrontend.models.TestData.UserData.validNSIPayload
 
 class HTSEventSpec extends TestSupport {
 
@@ -25,11 +25,11 @@ class HTSEventSpec extends TestSupport {
 
   "EmailChanged" must {
     "be created with the appropriate auditSource and auditDetails" in {
-      val event = EmailChanged(validNSIUserInfo.nino, "old-email@test.com", "new-email@test.com", true, "path")
+      val event = EmailChanged(validNSIPayload.nino, "old-email@test.com", "new-email@test.com", true, "path")
       event.value.auditSource shouldBe appName
       event.value.auditType shouldBe "EmailChanged"
       event.value.detail shouldBe Map[String, String](
-        "nino" → validNSIUserInfo.nino, "originalEmail" → "old-email@test.com", "newEmail" → "new-email@test.com", "duringRegistrationJourney" → "true")
+        "nino" → validNSIPayload.nino, "originalEmail" → "old-email@test.com", "newEmail" → "new-email@test.com", "duringRegistrationJourney" → "true")
       event.value.tags.get("path") shouldBe Some("path")
     }
   }
@@ -44,10 +44,10 @@ class HTSEventSpec extends TestSupport {
     }
 
     "be created with the appropriate auditSource and auditDetails incase of missing_email_record" in {
-      val event = SuspiciousActivity(Some(validNSIUserInfo.nino), "missing_email_record", "path")
+      val event = SuspiciousActivity(Some(validNSIPayload.nino), "missing_email_record", "path")
       event.value.auditSource shouldBe appName
       event.value.auditType shouldBe "SuspiciousActivity"
-      event.value.detail shouldBe Map[String, String]("nino" → validNSIUserInfo.nino, "reason" → "missing_email_record")
+      event.value.detail shouldBe Map[String, String]("nino" → validNSIPayload.nino, "reason" → "missing_email_record")
       event.value.tags.get("path") shouldBe Some("path")
     }
   }

--- a/test/uk/gov/hmrc/helptosavefrontend/models/NSIPayloadSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/models/NSIPayloadSpec.scala
@@ -20,35 +20,35 @@ import java.time.LocalDate
 
 import org.scalatest.{Matchers, WordSpec}
 import play.api.libs.json._
-import uk.gov.hmrc.helptosavefrontend.models.TestData.UserData.{validNSIUserInfo, validUserInfo}
-import uk.gov.hmrc.helptosavefrontend.models.userinfo.{Address, NSIUserInfo, UserInfo}
+import uk.gov.hmrc.helptosavefrontend.models.TestData.UserData.{validNSIPayload, validUserInfo}
+import uk.gov.hmrc.helptosavefrontend.models.userinfo.{Address, NSIPayload, UserInfo}
 
-class NSIUserInfoSpec extends WordSpec with Matchers {
+class NSIPayloadSpec extends WordSpec with Matchers {
 
-  val email = validNSIUserInfo.contactDetails.email
+  val email = validNSIPayload.contactDetails.email
 
-  "The NSIUSerInfo" must {
+  "The NSIPayload" must {
 
     "have JSON format" which {
 
-      "reads and writes NSIUserInfo" in {
-        Json.fromJson[NSIUserInfo](Json.toJson(validNSIUserInfo)) shouldBe JsSuccess(validNSIUserInfo)
+      "reads and writes NSIPayload" in {
+        Json.fromJson[NSIPayload](Json.toJson(validNSIPayload)) shouldBe JsSuccess(validNSIPayload)
       }
 
       "reads and writes dates in the format 'yyyyMMdd'" in {
         val date = LocalDate.of(1234, 5, 6)
 
         // check the happy path
-        val json1 = Json.toJson(validNSIUserInfo.copy(dateOfBirth = date))
+        val json1 = Json.toJson(validNSIPayload.copy(dateOfBirth = date))
         (json1 \ "dateOfBirth").get shouldBe JsString("12340506")
 
         // check the read will fail if the date is in the wrong format
         val json2 = json1.as[JsObject] ++ Json.obj("dateOfBirth" → JsString("not a date"))
-        Json.fromJson[NSIUserInfo](json2).isError shouldBe true
+        Json.fromJson[NSIPayload](json2).isError shouldBe true
 
         // check that read will fail if the date is not a string
         val json3 = json1.as[JsObject] ++ Json.obj("dateOfBirth" → JsNumber(0))
-        Json.fromJson[NSIUserInfo](json3).isError shouldBe true
+        Json.fromJson[NSIPayload](json3).isError shouldBe true
       }
     }
 
@@ -57,47 +57,47 @@ class NSIUserInfoSpec extends WordSpec with Matchers {
       "takes in a UserInfo" which {
 
         "converts appropriately" in {
-          NSIUserInfo(validUserInfo, email) shouldBe validNSIUserInfo
+          NSIPayload(validUserInfo, email) shouldBe validNSIPayload
         }
 
         "removes new line, tab and carriage return in forename" in {
           val modifiedForename = "\n\t\rname\t"
-          val userInfo = NSIUserInfo(validUserInfo.copy(forename = modifiedForename), email)
+          val userInfo = NSIPayload(validUserInfo.copy(forename = modifiedForename), email)
           userInfo.forename shouldBe "name"
         }
 
         "removes white spaces in forename" in {
           val forenameWithSpaces = " " + "forename" + " "
-          val userInfo = NSIUserInfo(validUserInfo.copy(forename = forenameWithSpaces), email)
+          val userInfo = NSIPayload(validUserInfo.copy(forename = forenameWithSpaces), email)
           userInfo.forename shouldBe "forename"
         }
 
         "removes spaces, tabs, new lines and carriage returns from a double barrel forename" in {
           val forenameDoubleBarrel = "   John\t\n\r   Paul\t\n\r   "
-          val userInfo = NSIUserInfo(validUserInfo.copy(forename = forenameDoubleBarrel), email)
+          val userInfo = NSIPayload(validUserInfo.copy(forename = forenameDoubleBarrel), email)
           userInfo.forename shouldBe "John Paul"
         }
 
         "removes spaces, tabs, new lines and carriage returns from a double barrel forename with a hyphen" in {
           val forenameDoubleBarrel = "   John\t\n\r-Paul\t\n\r   "
-          val userInfo = NSIUserInfo(validUserInfo.copy(forename = forenameDoubleBarrel), email)
+          val userInfo = NSIPayload(validUserInfo.copy(forename = forenameDoubleBarrel), email)
           userInfo.forename shouldBe "John -Paul"
         }
 
         "removes whitespace from surname" in {
-          val userInfo = NSIUserInfo(validUserInfo.copy(surname = " surname"), email)
+          val userInfo = NSIPayload(validUserInfo.copy(surname = " surname"), email)
           userInfo.surname shouldBe "surname"
         }
 
         "removes leading and trailing whitespaces, tabs, new lines and carriage returns from double barrel surname" in {
           val modifiedSurname = "   Luis\t\n\r   Guerra\t\n\r   "
-          val userInfo = NSIUserInfo(validUserInfo.copy(surname = modifiedSurname), email)
+          val userInfo = NSIPayload(validUserInfo.copy(surname = modifiedSurname), email)
           userInfo.surname shouldBe "Luis Guerra"
         }
 
         "removes leading and trailing whitespaces, tabs, new lines and carriage returns from double barrel surname with a hyphen" in {
           val modifiedSurname = "   Luis\t\n\r-Guerra\t\n\r   "
-          val userInfo = NSIUserInfo(validUserInfo.copy(surname = " " + modifiedSurname), email)
+          val userInfo = NSIPayload(validUserInfo.copy(surname = " " + modifiedSurname), email)
           userInfo.surname shouldBe "Luis -Guerra"
         }
 
@@ -115,7 +115,7 @@ class NSIUserInfoSpec extends WordSpec with Matchers {
               None
             )
           val ui: UserInfo = validUserInfo.copy(address = specialAddress)
-          val userInfo = NSIUserInfo(ui, email)
+          val userInfo = NSIPayload(ui, email)
           userInfo.contactDetails.address1 shouldBe "address line1"
           userInfo.contactDetails.address2 shouldBe "line2"
           userInfo.contactDetails.address3 shouldBe Some("line3")
@@ -135,7 +135,7 @@ class NSIUserInfoSpec extends WordSpec with Matchers {
           )
 
           val ui: UserInfo = validUserInfo.copy(address = specialAddress)
-          val userInfo = NSIUserInfo(ui, email)
+          val userInfo = NSIPayload(ui, email)
           userInfo.contactDetails.address1 shouldBe "Address line1"
           userInfo.contactDetails.address2 shouldBe "Address line2"
           userInfo.contactDetails.address3 shouldBe Some("Address line3")
@@ -159,7 +159,7 @@ class NSIUserInfoSpec extends WordSpec with Matchers {
 
           val ui: UserInfo = validUserInfo.copy(forename = longName, surname = longSurname, address = specialAddress)
 
-          val userInfo = NSIUserInfo(ui, email)
+          val userInfo = NSIPayload(ui, email)
           userInfo.forename shouldBe "John Paul Harry"
           userInfo.surname shouldBe "Smith Brown"
           userInfo.contactDetails.address1 shouldBe "Address line1"
@@ -174,18 +174,18 @@ class NSIUserInfoSpec extends WordSpec with Matchers {
         "filters out country codes equal to the string 'other'" in {
           Set("other", "OTHER", "Other").foreach{ other ⇒
             val ui: UserInfo = validUserInfo.copy(address = validUserInfo.address.copy(country = Some(other)))
-            NSIUserInfo(ui, email).contactDetails.countryCode shouldBe None
+            NSIPayload(ui, email).contactDetails.countryCode shouldBe None
           }
         }
 
         "takes the first two characters only of country codes" in {
           val ui: UserInfo = validUserInfo.copy(address = validUserInfo.address.copy(country = Some("ABCDEF")))
-          NSIUserInfo(ui, email).contactDetails.countryCode shouldBe Some("AB")
+          NSIPayload(ui, email).contactDetails.countryCode shouldBe Some("AB")
         }
 
         "returns a blank string for the postcode if it is not present" in {
           val ui: UserInfo = validUserInfo.copy(address = validUserInfo.address.copy(postcode = None))
-          NSIUserInfo(ui, email).contactDetails.postcode shouldBe ""
+          NSIPayload(ui, email).contactDetails.postcode shouldBe ""
         }
 
         "returns a blank string for address lines 1 or 2 if they are missing" in {
@@ -193,21 +193,21 @@ class NSIUserInfoSpec extends WordSpec with Matchers {
           val ui1: UserInfo = validUserInfo.copy(address =
             validUserInfo.address.copy(lines = List()))
 
-          NSIUserInfo(ui1, email).contactDetails.address1 shouldBe ""
-          NSIUserInfo(ui1, email).contactDetails.address2 shouldBe ""
-          NSIUserInfo(ui1, email).contactDetails.address3 shouldBe None
-          NSIUserInfo(ui1, email).contactDetails.address4 shouldBe None
-          NSIUserInfo(ui1, email).contactDetails.address5 shouldBe None
+          NSIPayload(ui1, email).contactDetails.address1 shouldBe ""
+          NSIPayload(ui1, email).contactDetails.address2 shouldBe ""
+          NSIPayload(ui1, email).contactDetails.address3 shouldBe None
+          NSIPayload(ui1, email).contactDetails.address4 shouldBe None
+          NSIPayload(ui1, email).contactDetails.address5 shouldBe None
 
           // check when there is only one address line
           val ui2: UserInfo = validUserInfo.copy(address =
             validUserInfo.address.copy(lines = List("line")))
 
-          NSIUserInfo(ui2, email).contactDetails.address1 shouldBe "line"
-          NSIUserInfo(ui2, email).contactDetails.address2 shouldBe ""
-          NSIUserInfo(ui2, email).contactDetails.address3 shouldBe None
-          NSIUserInfo(ui2, email).contactDetails.address4 shouldBe None
-          NSIUserInfo(ui2, email).contactDetails.address5 shouldBe None
+          NSIPayload(ui2, email).contactDetails.address1 shouldBe "line"
+          NSIPayload(ui2, email).contactDetails.address2 shouldBe ""
+          NSIPayload(ui2, email).contactDetails.address3 shouldBe None
+          NSIPayload(ui2, email).contactDetails.address4 shouldBe None
+          NSIPayload(ui2, email).contactDetails.address5 shouldBe None
         }
 
         "filter out address lines which are empty" in {
@@ -220,11 +220,11 @@ class NSIUserInfoSpec extends WordSpec with Matchers {
           val ui: UserInfo = validUserInfo.copy(address =
             validUserInfo.address.copy(lines = willBeFilteredOut ::: List("line")))
 
-          NSIUserInfo(ui, email).contactDetails.address1 shouldBe "line"
-          NSIUserInfo(ui, email).contactDetails.address2 shouldBe ""
-          NSIUserInfo(ui, email).contactDetails.address3 shouldBe None
-          NSIUserInfo(ui, email).contactDetails.address4 shouldBe None
-          NSIUserInfo(ui, email).contactDetails.address5 shouldBe None
+          NSIPayload(ui, email).contactDetails.address1 shouldBe "line"
+          NSIPayload(ui, email).contactDetails.address2 shouldBe ""
+          NSIPayload(ui, email).contactDetails.address3 shouldBe None
+          NSIPayload(ui, email).contactDetails.address4 shouldBe None
+          NSIPayload(ui, email).contactDetails.address5 shouldBe None
         }
 
       }

--- a/test/uk/gov/hmrc/helptosavefrontend/models/TestData.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/models/TestData.scala
@@ -83,7 +83,7 @@ object TestData {
       val nsiValidContactDetails = ContactDetails(addressLine1, addressLine2, Some(addressLine3), None, None, postcode, Some(country), email)
       val nsiPayload =
         NSIPayload(forename, surname, dateOfBirth, nino,
-                    ContactDetails(addressLine1, addressLine2, Some(addressLine3), None, None, postcode, Some(country), email)
+                   ContactDetails(addressLine1, addressLine2, Some(addressLine3), None, None, postcode, Some(country), email)
         )
 
       (userInfo, nsiValidContactDetails, nsiPayload)

--- a/test/uk/gov/hmrc/helptosavefrontend/models/TestData.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/models/TestData.scala
@@ -22,8 +22,8 @@ import org.scalacheck.Gen
 import uk.gov.hmrc.helptosavefrontend.models.HTSSession.EligibleWithUserInfo
 import uk.gov.hmrc.helptosavefrontend.models.eligibility.EligibilityCheckResponse
 import uk.gov.hmrc.helptosavefrontend.models.eligibility.EligibilityCheckResult.{Eligible, Ineligible}
-import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIUserInfo.ContactDetails
-import uk.gov.hmrc.helptosavefrontend.models.userinfo.{Address, NSIUserInfo, UserInfo}
+import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIPayload.ContactDetails
+import uk.gov.hmrc.helptosavefrontend.models.userinfo.{Address, NSIPayload, UserInfo}
 import uk.gov.hmrc.helptosavefrontend.testutil._
 import uk.gov.hmrc.smartstub.AutoGen.{GenProvider, instance}
 import uk.gov.hmrc.smartstub.{AutoGen, _}
@@ -66,7 +66,7 @@ object TestData {
     /**
      * Valid user details which will pass NSI validation checks
      */
-    val (validUserInfo, nsiValidContactDetails, validNSIUserInfo) = {
+    val (validUserInfo, nsiValidContactDetails, validNSIPayload) = {
       val (forename, surname) = "Tyrion" → "Lannister"
       val dateOfBirth = LocalDate.ofEpochDay(0L)
       val addressLine1 = "Casterly Rock"
@@ -81,12 +81,12 @@ object TestData {
 
       val userInfo = UserInfo(forename, surname, nino, dateOfBirth, Some(email), address)
       val nsiValidContactDetails = ContactDetails(addressLine1, addressLine2, Some(addressLine3), None, None, postcode, Some(country), email)
-      val nsiUserInfo =
-        NSIUserInfo(forename, surname, dateOfBirth, nino,
+      val nsiPayload =
+        NSIPayload(forename, surname, dateOfBirth, nino,
                     ContactDetails(addressLine1, addressLine2, Some(addressLine3), None, None, postcode, Some(country), email)
         )
 
-      (userInfo, nsiValidContactDetails, nsiUserInfo)
+      (userInfo, nsiValidContactDetails, nsiPayload)
     }
   }
 

--- a/test/uk/gov/hmrc/helptosavefrontend/models/TestData.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/models/TestData.scala
@@ -83,7 +83,7 @@ object TestData {
       val nsiValidContactDetails = ContactDetails(addressLine1, addressLine2, Some(addressLine3), None, None, postcode, Some(country), email)
       val nsiPayload =
         NSIPayload(forename, surname, dateOfBirth, nino,
-                   ContactDetails(addressLine1, addressLine2, Some(addressLine3), None, None, postcode, Some(country), email)
+                   ContactDetails(addressLine1, addressLine2, Some(addressLine3), None, None, postcode, Some(country), email), "online", None, "V2.0", "systemId"
         )
 
       (userInfo, nsiValidContactDetails, nsiPayload)

--- a/test/uk/gov/hmrc/helptosavefrontend/services/HelpToSaveServiceSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/services/HelpToSaveServiceSpec.scala
@@ -25,11 +25,11 @@ import play.api.libs.json.{JsObject, JsValue, Json}
 import uk.gov.hmrc.helptosavefrontend.TestSupport
 import uk.gov.hmrc.helptosavefrontend.connectors.HelpToSaveConnector
 import uk.gov.hmrc.helptosavefrontend.models.TestData.Eligibility.randomEligibility
-import uk.gov.hmrc.helptosavefrontend.models.TestData.UserData.validNSIUserInfo
+import uk.gov.hmrc.helptosavefrontend.models.TestData.UserData.validNSIPayload
 import uk.gov.hmrc.helptosavefrontend.models._
 import uk.gov.hmrc.helptosavefrontend.models.account.{Account, AccountNumber, Blocking}
 import uk.gov.hmrc.helptosavefrontend.models.register.CreateAccountRequest
-import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIUserInfo
+import uk.gov.hmrc.helptosavefrontend.models.userinfo.NSIPayload
 import uk.gov.hmrc.helptosavefrontend.services.HelpToSaveServiceImpl.{SubmissionFailure, SubmissionSuccess}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
@@ -127,7 +127,7 @@ class HelpToSaveServiceSpec extends TestSupport {
 
     "createAccount" must {
 
-      val createAccountRequest = CreateAccountRequest(validNSIUserInfo, 7)
+      val createAccountRequest = CreateAccountRequest(validNSIPayload, 7)
 
         def mockCreateAccount(response: Option[HttpResponse]) = {
           (htsConnector.createAccount(_: CreateAccountRequest)(_: HeaderCarrier, _: ExecutionContext)).expects(createAccountRequest, *, *)
@@ -166,10 +166,10 @@ class HelpToSaveServiceSpec extends TestSupport {
 
     "update email" must {
 
-      val nsiUserInfo = validNSIUserInfo
+      val nsiPayload = validNSIPayload
 
         def mockUpdateEmail(response: Option[HttpResponse]) = {
-          (htsConnector.updateEmail(_: NSIUserInfo)(_: HeaderCarrier, _: ExecutionContext)).expects(nsiUserInfo, *, *)
+          (htsConnector.updateEmail(_: NSIPayload)(_: HeaderCarrier, _: ExecutionContext)).expects(nsiPayload, *, *)
             .returning(response.fold[Future[HttpResponse]](Future.failed(new Exception("oh no!")))(r ⇒ Future.successful(r)))
         }
 
@@ -177,7 +177,7 @@ class HelpToSaveServiceSpec extends TestSupport {
 
         mockUpdateEmail(Some(HttpResponse(200)))
 
-        val result = htsService.updateEmail(nsiUserInfo)
+        val result = htsService.updateEmail(nsiPayload)
         result.value.futureValue shouldBe Right(())
 
       }
@@ -185,14 +185,14 @@ class HelpToSaveServiceSpec extends TestSupport {
       "handle failure response" in {
         mockUpdateEmail(Some(HttpResponse(400)))
 
-        val result = htsService.updateEmail(nsiUserInfo)
+        val result = htsService.updateEmail(nsiPayload)
         result.value.futureValue shouldBe Left("Received unexpected status 400 from NS&I proxy while trying to update email. Body was null")
       }
 
       "recover from unexpected errors" in {
         mockUpdateEmail(None)
 
-        val result = htsService.updateEmail(nsiUserInfo)
+        val result = htsService.updateEmail(nsiPayload)
         result.value.futureValue should be(Left("Encountered error while trying to update email: oh no!"))
       }
     }


### PR DESCRIPTION
tested locally and bank details, version, systemId are successfully logged in the stub 
```
2018-08-29 10:15:47,909 level=[ INFO] message=[Responding to create account with status: 201, nsiPayload from the request is: NSIPayload(Chaim Rollins,Geraldine Blackwell,2018-05-07,EL071878B,ContactDetails(985 West First Court,12 Nobel Drive,Some(472 Rocky Hague Avenue),Some(11 White Clarendon Lane),Some(64 East Green Clarendon Court),FR32LA,Some(GB),Some(yordan.angelov@digital.hmrc.gov.uk),None,02),online,Some(BankDetails(80-14-97,33434343,Some(11111),343b 334)),V2.0,MDTP REGISTRATION) ]  logger=[uk.gov.hmrc.helptosavestub.controllers.NSIController] thread=[application-akka.actor.default-dispatcher-7] rid=[] user=[] 
```