### PR TITLE
HTS-1511 - added googleusercontent to content security policy

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -23,7 +23,7 @@ play.http.router = prod.Routes
 #play.ws.ssl.disabledKeyAlgorithms = "DHE keySize < 2048, ECDH keySize < 2048, ECDHE keySize < 2048, RSA keySize < 2048, DSA keySize < 2048, EC keySize < 224"
 
 # to learn why this was included: /display/TEC/2016/03/14/Setting+Security+Headers+in+frontend+services
-play.filters.headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 localhost:9250 www.google-analytics.com data:"
+play.filters.headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 localhost:9250 www.google-analytics.com data:; img-src 'self' www.google-analytics.com *.googleusercontent.com "
 
 # An ApplicationLoader that uses Guice to bootstrap the application.
 play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"


### PR DESCRIPTION
Added *.googleusercontent to content security policy following these instructions: 

https://developers.google.com/web/fundamentals/app-install-banners/native