### PR TITLE
DLS-2796 change scheduled maintenance separator from space to slash, …

### DIFF
--- a/app/uk/gov/hmrc/helptosavefrontend/util/MaintenanceSchedule.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/util/MaintenanceSchedule.scala
@@ -29,7 +29,7 @@ object MaintenanceSchedule {
   def parse(x: String): MaintenanceSchedule =
     MaintenanceSchedule(
       x.split(",")
-        .map(_.split(" ") match {
+        .map(_.split("/") match {
           case Array(start, end) => Maintenance(LocalDateTime.parse(start), LocalDateTime.parse(end))
         })
     )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -253,6 +253,6 @@ youtube-embeds {
   how-withdrawals-affect-bonuses = "xQEcsaiu0TE"
 }
 
-scheduled-maintenance-times="2020-06-09T15:20 2020-06-09T15:59,2020-05-28T18:51 2020-05-28T08:58,2020-05-28T18:15 2020-05-28T18:50"
+scheduled-maintenance-times="2020-06-09T15:20/2020-06-09T15:59,2020-05-28T18:51/2020-05-28T08:58,2020-05-28T18:15/2020-05-28T18:50"
 
 enableLanguageSwitching = true // set to true for local testing, override in Prod to start with

--- a/test/uk/gov/hmrc/helptosavefrontend/util/MaintenanceScheduleSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/util/MaintenanceScheduleSpec.scala
@@ -22,7 +22,7 @@ class MaintenanceScheduleSpec extends UnitSpec {
 
   "MatchingSchedule" must {
     "return the last end time" in {
-      val schedule = "2020-06-03T12:50 2020-06-03T13:01,2020-06-03T12:51 2020-06-03T13:02"
+      val schedule = "2020-06-03T12:50/2020-06-03T13:01,2020-06-03T12:51/2020-06-03T13:02"
       val original = MaintenanceSchedule.parse(schedule).endOfMaintenance(LocalDateTime.parse("2020-06-03T12:52"))
       val expected = Some(LocalDateTime.parse("2020-06-03T13:02"))
 
@@ -30,7 +30,7 @@ class MaintenanceScheduleSpec extends UnitSpec {
     }
 
     "return none when outside maintenance window" in {
-      val schedule = "2020-06-03T12:50 2020-06-03T13:01"
+      val schedule = "2020-06-03T12:50/2020-06-03T13:01"
       val original = MaintenanceSchedule.parse(schedule).endOfMaintenance(LocalDateTime.parse("2020-06-03T13:03"))
       val expected = None
 


### PR DESCRIPTION
DLS-2796 change scheduled maintenance separator from space to slash because spaces not allowed in hmrc config without base64 - which would be obstructive in this case