### PR TITLE
DLS-2799 Disabling the JUnit XML Reporter, …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,6 +87,7 @@ lazy val microservice = Project(appName, file("."))
   .enablePlugins(
     Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory) ++ plugins: _*
   )
+  .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(PlayKeys.playDefaultPort := 7000)
   .settings(
     libraryDependencies ++= appDependencies


### PR DESCRIPTION
DLS-2799 Disabling the JUnit XML Reporter, required to prevent https://github.com/scalatest/scalatest/issues/1427