### PR TITLE
DLS-5493 - Play 2.8.16/Bootstrap 5.24.0 upgrade

### DIFF
--- a/app/uk/gov/hmrc/helptosavefrontend/auth/HelpToSaveAuth.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/auth/HelpToSaveAuth.scala
@@ -22,7 +22,7 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.syntax.apply._
 import cats.syntax.option._
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import play.api.mvc.{Action, AnyContent, Request, Result}
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.Predicate
@@ -216,7 +216,7 @@ trait HelpToSaveAuth extends AuthorisedFunctions with AuthRedirects with Logging
     val validation: ValidOrMissingUserInfo[UserInfo] =
       (givenNameValidation, surnameValidation, dateOfBirthValidation, addressValidation).mapN {
         case (givenName, surname, jodaDob, address) ⇒
-          UserInfo(givenName, surname, nino, toJavaDate(jodaDob), email.filter(_.nonEmpty), Address(address))
+          UserInfo(givenName, surname, nino, jodaDob, email.filter(_.nonEmpty), Address(address))
       }
 
     validation

--- a/app/uk/gov/hmrc/helptosavefrontend/config/Filters.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/config/Filters.scala
@@ -21,13 +21,12 @@ import configs.syntax._
 import play.api.Configuration
 import play.api.http.HttpFilters
 import play.api.mvc.EssentialFilter
-import uk.gov.hmrc.play.bootstrap.frontend.filters.FrontendFilters
 
 @Singleton
 class Filters @Inject() (
                           configuration: Configuration,
                           AllowListFilter: AllowListFilter,
-                          frontendFilters: FrontendFilters
+                          frontendFilters: HttpFilters
 ) extends HttpFilters {
 
   val allowListFilterEnabled: Boolean =

--- a/app/uk/gov/hmrc/helptosavefrontend/models/HtsAuth.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/models/HtsAuth.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.helptosavefrontend.models
 
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
 import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.{Name => CoreName, _}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,7 @@ object AppDependencies {
   val compile = Seq(
     hmrc                %% "govuk-template"             % "5.72.0-play-28",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"      % "0.68.0",
-    hmrc                %% "bootstrap-frontend-play-28" % "5.3.0",
+    hmrc                %% "bootstrap-frontend-play-28" % "5.24.0",
     hmrc                %% "play-ui"                    % "9.5.0-play-28",
     hmrc                %% "play-language"              % "5.1.0-play-28",
     "com.github.kxbmap" %% "configs"                     % "0.4.4",
@@ -29,7 +29,7 @@ object AppDependencies {
     "org.scalamock"          %% "scalamock-scalatest-support" % "3.6.0"             % "test",
     "com.typesafe.play"      %% "play"                        % "2.8.16"             % "test",
     "com.miguno.akka"        %% "akka-mock-scheduler"         % "0.5.5"             % "test",
-    "uk.gov.hmrc"            %% "bootstrap-test-play-28"      % "5.16.0"            % "test",
+    "uk.gov.hmrc"            %% "bootstrap-test-play-28"      % "5.24.0"            % "test",
     "com.vladsch.flexmark"    %  "flexmark-all"                 % "0.35.10"           % "test"
   )
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -27,7 +27,7 @@ object AppDependencies {
     "org.scalatestplus"      %% "scalatestplus-scalacheck"    % "3.1.0.0-RC2"       % "test",
     "org.scalatestplus"      %% "scalatestplus-mockito"       % "1.0.0-M2"          % "test",
     "org.scalamock"          %% "scalamock-scalatest-support" % "3.6.0"             % "test",
-    "com.typesafe.play"      %% "play"                        % "2.8.8"             % "test",
+    "com.typesafe.play"      %% "play"                        % "2.8.16"             % "test",
     "com.miguno.akka"        %% "akka-mock-scheduler"         % "0.5.5"             % "test",
     "uk.gov.hmrc"            %% "bootstrap-test-play-28"      % "5.16.0"            % "test",
     "com.vladsch.flexmark"    %  "flexmark-all"                 % "0.35.10"           % "test"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-bobby" % "3.5.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8" exclude ("org.slf4j", "slf4j-simple"))
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16" exclude ("org.slf4j", "slf4j-simple"))
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.0")
 

--- a/test/uk/gov/hmrc/helptosavefrontend/auth/HelpToSaveAuthSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/auth/HelpToSaveAuthSpec.scala
@@ -75,7 +75,7 @@ class HelpToSaveAuthSpec extends ControllerSpecWithGuiceApp with AuthSupport {
       firstName,
       lastName,
       nino,
-      toJavaDate(dob),
+      dob,
       Some(emailStr),
       Address(List(line1, line2, line3), Some(postCode), Some(countryCode))
     )

--- a/test/uk/gov/hmrc/helptosavefrontend/config/FiltersSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/config/FiltersSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.helptosavefrontend.config
 import akka.stream.ActorMaterializer
 import com.kenshoo.play.metrics.MetricsFilter
 import play.api.Configuration
+import play.api.http.DefaultHttpFilters
 import play.api.mvc.EssentialFilter
 import play.filters.csrf.CSRFFilter
 import play.filters.headers.SecurityHeadersFilter
@@ -41,28 +42,8 @@ class FiltersSpec extends ControllerSpecWithGuiceAppPerTest {
   val mockWhiteListFilter = mock[uk.gov.hmrc.play.bootstrap.frontend.filters.AllowlistFilter]
   val mockSessionIdFilter = mock[SessionIdFilter]
 
-  class TestableFrontendFilters
-      extends FrontendFilters(
-        stub[Configuration],
-        stub[LoggingFilter],
-        stub[HeadersFilter],
-        stub[SecurityHeadersFilter],
-        stub[FrontendAuditFilter],
-        stub[MetricsFilter],
-        stub[DeviceIdFilter],
-        stub[CSRFFilter],
-        stub[SessionCookieCryptoFilter],
-        stub[SessionTimeoutFilter],
-        mockCacheControllerFilter,
-        mockMDCFilter,
-        mockWhiteListFilter,
-        mockSessionIdFilter
-      ) {
-    lazy val enableSecurityHeaderFilter: Boolean = false
-    override val filters: Seq[EssentialFilter] = Seq()
-  }
 
-  val frontendFilters = new TestableFrontendFilters
+  val frontendFilters = new DefaultHttpFilters()
   val allowListFilter = mock[AllowListFilter]
 
   "Filters" must {

--- a/test/uk/gov/hmrc/helptosavefrontend/config/FiltersSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/config/FiltersSpec.scala
@@ -16,19 +16,9 @@
 
 package uk.gov.hmrc.helptosavefrontend.config
 
-import akka.stream.ActorMaterializer
-import com.kenshoo.play.metrics.MetricsFilter
 import play.api.Configuration
 import play.api.http.DefaultHttpFilters
-import play.api.mvc.EssentialFilter
-import play.filters.csrf.CSRFFilter
-import play.filters.headers.SecurityHeadersFilter
 import uk.gov.hmrc.helptosavefrontend.controllers.ControllerSpecWithGuiceAppPerTest
-import uk.gov.hmrc.integration.servicemanager.ServiceManagerClient.system
-import uk.gov.hmrc.play.bootstrap.filters._
-import uk.gov.hmrc.play.bootstrap.frontend.filters.crypto.SessionCookieCryptoFilter
-import uk.gov.hmrc.play.bootstrap.frontend.filters.deviceid.DeviceIdFilter
-import uk.gov.hmrc.play.bootstrap.frontend.filters.{FrontendFilters, _}
 
 class FiltersSpec extends ControllerSpecWithGuiceAppPerTest {
   val frontendFilters = new DefaultHttpFilters()

--- a/test/uk/gov/hmrc/helptosavefrontend/config/FiltersSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/config/FiltersSpec.scala
@@ -31,20 +31,8 @@ import uk.gov.hmrc.play.bootstrap.frontend.filters.deviceid.DeviceIdFilter
 import uk.gov.hmrc.play.bootstrap.frontend.filters.{FrontendFilters, _}
 
 class FiltersSpec extends ControllerSpecWithGuiceAppPerTest {
-
-  // can't use scalamock for CacheControlFilter since a logging statement during class
-  // construction requires a parameter from the CacheControlConfig. Using scalamock
-  // reuslts in a NullPointerException since no CacheControlConfig is there
-  implicit val mat: ActorMaterializer = ActorMaterializer()
-  val mockCacheControllerFilter = new CacheControlFilter(CacheControlConfig(), mat)
-
-  val mockMDCFilter = new MDCFilter(fakeApplication.materializer, fakeApplication.configuration, "")
-  val mockWhiteListFilter = mock[uk.gov.hmrc.play.bootstrap.frontend.filters.AllowlistFilter]
-  val mockSessionIdFilter = mock[SessionIdFilter]
-
-
   val frontendFilters = new DefaultHttpFilters()
-  val allowListFilter = mock[AllowListFilter]
+  val allowListFilter: AllowListFilter = mock[AllowListFilter]
 
   "Filters" must {
 

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/AccountHolderControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/AccountHolderControllerSpec.scala
@@ -166,10 +166,13 @@ class AccountHolderControllerSpec
       val email = "email@test.com"
 
       val fakePostRequest =
-        fakeRequest.withFormUrlEncodedBody("new-email-address" → email)
+        fakeRequest.withMethod("POST").withFormUrlEncodedBody("new-email-address" → email)
 
       def submit(email: String): Future[Result] =
-        controller.onSubmit()(FakeRequest().withFormUrlEncodedBody("new-email-address" → email))
+        controller.onSubmit()(
+          FakeRequest()
+            .withMethod("POST")
+            .withFormUrlEncodedBody("new-email-address" → email))
 
       behave like commonEnrolmentBehaviour(
         () ⇒ submit("email"),
@@ -225,7 +228,7 @@ class AccountHolderControllerSpec
 
       "show an error page if the write to session cache fails" in {
         val fakePostRequest =
-          FakeRequest().withFormUrlEncodedBody("new-email-address" → email)
+          FakeRequest().withMethod("POST").withFormUrlEncodedBody("new-email-address" → email)
         inSequence {
           mockAuthWithNINOAndName(AuthWithCL200)(mockedNINOAndNameRetrieval)
           mockEnrolmentCheck()(Right(enrolled))
@@ -239,7 +242,7 @@ class AccountHolderControllerSpec
 
       "show an error page if the email verification fails" in {
         val fakePostRequest =
-          FakeRequest().withFormUrlEncodedBody("new-email-address" → email)
+          FakeRequest().withMethod("POST").withFormUrlEncodedBody("new-email-address" → email)
         inSequence {
           mockAuthWithNINOAndName(AuthWithCL200)(mockedNINOAndNameRetrieval)
           mockEnrolmentCheck()(Right(enrolled))

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/AuthSupport.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/AuthSupport.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.helptosavefrontend.controllers
 
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import org.scalamock.scalatest.MockFactory
 import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
 import uk.gov.hmrc.auth.core._
@@ -76,7 +76,7 @@ trait AuthSupport extends MockFactory {
   val nsiPayload = NSIPayload(
     firstName,
     lastName,
-    toJavaDate(dob),
+    dob,
     nino,
     ContactDetails(
       line1,

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/BankAccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/BankAccountControllerSpec.scala
@@ -193,6 +193,7 @@ class BankAccountControllerSpec
     "handling submitBankDetails" must {
 
       val submitBankDetailsRequest = fakeRequest
+        .withMethod("POST")
         .withFormUrlEncodedBody(
           "sortCode" → "123456",
           "accountNumber" -> "12345678",
@@ -214,7 +215,8 @@ class BankAccountControllerSpec
         }
 
         val result =
-          csrfAddToken(controller.submitBankDetails())(fakeRequest.withFormUrlEncodedBody("rollNumber" → "a"))
+          csrfAddToken(controller.submitBankDetails())(
+            fakeRequest.withMethod("POST").withFormUrlEncodedBody("rollNumber" → "a"))
         status(result) shouldBe Status.OK
         contentAsString(result) should include("Enter sort code")
         contentAsString(result) should include("Enter account number")

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/EligibilityCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/EligibilityCheckControllerSpec.scala
@@ -684,7 +684,7 @@ class EligibilityCheckControllerSpec
         def missingUserInfoRetrieval(
           name: Option[String],
           surname: Option[String],
-          dob: Option[org.joda.time.LocalDate],
+          dob: Option[LocalDate],
           address: ItmpAddress
         ) =
           new ~(Some(Name(name, surname)), email) and dob and Some(ItmpName(name, None, surname)) and dob and Some(
@@ -694,12 +694,12 @@ class EligibilityCheckControllerSpec
         def isAddressInvalid(address: ItmpAddress): Boolean =
           !(address.line1.nonEmpty && address.line2.nonEmpty) || address.postCode.isEmpty
         def isNameInvalid(name: Option[String]): Boolean = name.forall(_.isEmpty)
-        def isDobInvalid(dob: Option[org.joda.time.LocalDate]) = dob.isEmpty
+        def isDobInvalid(dob: Option[LocalDate]) = dob.isEmpty
 
         case class TestParameters(
           name: Option[String],
           surname: Option[String],
-          dob: Option[org.joda.time.LocalDate],
+          dob: Option[LocalDate],
           address: ItmpAddress
         )
 
@@ -713,7 +713,7 @@ class EligibilityCheckControllerSpec
 
         val names: List[Option[String]] = List(Some("name"), None, Some(""))
 
-        val dobs: List[Option[org.joda.time.LocalDate]] = List(Some(org.joda.time.LocalDate.now()), None)
+        val dobs: List[Option[LocalDate]] = List(Some(LocalDate.now()), None)
 
         val testParams: List[TestParameters] = for {
           name ← names

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/EmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/EmailControllerSpec.scala
@@ -330,10 +330,11 @@ class EmailControllerSpec
 
       def selectEmailSubmit(newEmail: Option[String]): Future[Result] =
         newEmail.fold(
-          csrfAddToken(controller.selectEmailSubmit())(fakeRequest.withFormUrlEncodedBody("email" → "Yes"))
+          csrfAddToken(controller.selectEmailSubmit())(
+            fakeRequest.withMethod("POST").withFormUrlEncodedBody("email" → "Yes"))
         ) { e ⇒
           csrfAddToken(controller.selectEmailSubmit())(
-            fakeRequest.withFormUrlEncodedBody("email" → "No", "new-email" → e)
+            fakeRequest.withMethod("POST").withFormUrlEncodedBody("email" → "No", "new-email" → e)
           )
         }
 
@@ -503,10 +504,10 @@ class EmailControllerSpec
 
       def selectEmailSubmitReminder(newEmail: Option[String]): Future[Result] =
         newEmail.fold(
-          csrfAddToken(controller.selectEmailSubmitReminder())(fakeRequest.withFormUrlEncodedBody("email" → "Yes"))
+          csrfAddToken(controller.selectEmailSubmitReminder())(fakeRequest.withMethod("POST").withFormUrlEncodedBody("email" → "Yes"))
         ) { e ⇒
           csrfAddToken(controller.selectEmailSubmitReminder())(
-            fakeRequest.withFormUrlEncodedBody("email" → "No", "new-email" → e)
+            fakeRequest.withMethod("POST").withFormUrlEncodedBody("email" → "No", "new-email" → e)
           )
         }
 
@@ -873,7 +874,7 @@ class EmailControllerSpec
       val email = "email@test.com"
 
       def giveEmailSubmit(email: String): Future[Result] =
-        csrfAddToken(controller.giveEmailSubmit())(fakeRequest.withFormUrlEncodedBody("email" → email))
+        csrfAddToken(controller.giveEmailSubmit())(fakeRequest.withMethod("POST").withFormUrlEncodedBody("email" → email))
 
       "handle Digital(new applicant) users with no valid session in mongo" in {
 
@@ -1567,7 +1568,7 @@ class EmailControllerSpec
 
       def confirmEmailErrorSubmit(continue: Boolean): Future[Result] =
         csrfAddToken(controller.confirmEmailErrorSubmit())(
-          fakeRequest.withFormUrlEncodedBody("radio-inline-group" → continue.toString)
+          fakeRequest.withMethod("POST").withFormUrlEncodedBody("radio-inline-group" → continue.toString)
         )
 
       "handle Digital users and redirect to the email verify error page try later if there is no email for the user" in {

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/RegisterControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/RegisterControllerSpec.scala
@@ -704,7 +704,7 @@ class RegisterControllerSpec
     }
 
     "handling accessOrPayIn" must {
-      def fRequest(payIn: String) =  fakeRequest.withFormUrlEncodedBody("payInNow" -> payIn)
+      def fRequest(payIn: String) =  fakeRequest.withMethod("POST").withFormUrlEncodedBody("payInNow" -> payIn)
       def postAccessOrPayIn(payIn: String) = csrfAddToken(controller.accessOrPayIn())(fRequest(payIn))
 
       "show errors on the page" in {


### PR DESCRIPTION
 - Update Play to 2.8.16
 - Update Bootstrap to 5.24.0

~~Most changes are to use explicit body parsing (`Action.async(parse.***)` - "Making Play Less Flexible" article)~~ - reverted

Possible further changes:
 - ~~`Action.async(parse.anyContent)` -> Action.async(parse.unit) - body is not used~~ - reverted, as wasn't currently needed. I started introducing errors with the changes.
 - ~~Investigating encryption test failing inside IJ SBT~~ - we're calling the encryption library directly. It's a problem with that library.