### PR TITLE
Tom/dls 6232 HTS - Back links disappear with error

### DIFF
--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/EmailController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/EmailController.scala
@@ -108,7 +108,9 @@ class EmailController @Inject() (
               }
               Ok(selectEmail(eligibleWithEmail.email, emailFormWithData, Some(backLinkFromSession(s))))
           },
-          { case _ ⇒ SeeOther(routes.EmailController.getGiveEmailPage.url) }
+          { case _ ⇒
+            SeeOther(routes.EmailController.getGiveEmailPage.url)
+          }
         )(session)
       }
 

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/ReminderController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/ReminderController.scala
@@ -480,7 +480,6 @@ class ReminderController @Inject() (
       if (isFeatureEnabled) {
         checkIfAlreadyEnrolledAndDoneEligibilityChecks { s ⇒
           def bckLink: String = routes.ReminderController.getApplySavingsReminderPage.url
-
           s.reminderDetails.fold(
             Ok(
               reminderFrequencySet(
@@ -491,7 +490,7 @@ class ReminderController @Inject() (
               )
             )
           )(
-            reminderDetails ⇒
+            reminderDetails ⇒ {
               Ok(
                 reminderFrequencySet(
                   ReminderForm.giveRemindersDetailsForm(),
@@ -500,6 +499,7 @@ class ReminderController @Inject() (
                   Some(bckLink)
                 )
               )
+            }
           )
         }
       } else {
@@ -519,7 +519,8 @@ class ReminderController @Inject() (
                 reminderFrequencySet(
                   withErrors,
                   "none",
-                  "registration"
+                  "registration",
+                  Option(routes.EmailController.getSelectEmailPage.url)
                 )
               )
             },

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/ReminderController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/ReminderController.scala
@@ -437,7 +437,7 @@ class ReminderController @Inject() (
           .bindFromRequest()
           .fold(
             withErrors ⇒ {
-              Ok(applySavingsReminders(withErrors, "none"))
+              Ok(applySavingsReminders(withErrors, "none", Option(routes.EmailController.getSelectEmailPage.url)))
             },
             success ⇒
               if (success.reminderFrequency === "no") {

--- a/app/uk/gov/hmrc/helptosavefrontend/views/reminder/apply_savings_reminders.scala.html
+++ b/app/uk/gov/hmrc/helptosavefrontend/views/reminder/apply_savings_reminders.scala.html
@@ -38,7 +38,6 @@
         bodyClasses = None,
         isErrorPage = errorMessage.isDefined) {
 
-
         @navigate_back(backLink)
 
         @{if(errorMessage.isDefined)

--- a/app/uk/gov/hmrc/helptosavefrontend/views/reminder/apply_savings_reminders.scala.html
+++ b/app/uk/gov/hmrc/helptosavefrontend/views/reminder/apply_savings_reminders.scala.html
@@ -38,6 +38,7 @@
         bodyClasses = None,
         isErrorPage = errorMessage.isDefined) {
 
+
         @navigate_back(backLink)
 
         @{if(errorMessage.isDefined)


### PR DESCRIPTION
This small PR addresses an accessibility issue on HTS where specific back links would disappear upon triggering an error on the page - this was due to some missing URLs when calling the pages.

Validity checks => look fine
Axe checks => look fine
Unit tests => All pass