### PR TITLE
[DLS-6905] CSP update

### DIFF
--- a/app/uk/gov/hmrc/helptosavefrontend/views/helpers/youtube_embed.scala.html
+++ b/app/uk/gov/hmrc/helptosavefrontend/views/helpers/youtube_embed.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@(embedCode: String, maybeTitle: Option[String])(implicit request: Request[_], messages: play.api.i18n.Messages)
+@(embedCode: String, maybeTitle: Option[String])(implicit messages: play.api.i18n.Messages)
     <div class="videoWrapper">
         <iframe
         data-dnt-embed
@@ -24,10 +24,12 @@
         data-dnt-default-buttontext-left="@Messages("hts.global.dnt.default.button.with.title.text.left")"
         data-dnt-default-buttontext-right="@Messages("hts.global.dnt.default.button.with.title.text.right")"
         @maybeTitle.map{title => title="@title" }
+        style="border:0;"
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         <noscript>
             <iframe
             src="https://www.youtube.com/embed/@{embedCode}"
+            style="border:0;"
             allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </noscript>
     </div>

--- a/app/uk/gov/hmrc/helptosavefrontend/views/helpers/youtube_embed.scala.html
+++ b/app/uk/gov/hmrc/helptosavefrontend/views/helpers/youtube_embed.scala.html
@@ -14,7 +14,9 @@
  * limitations under the License.
  *@
 
-@(embedCode: String, maybeTitle: Option[String])(implicit messages: play.api.i18n.Messages)
+@import views.html.helper.CSPNonce
+
+@(embedCode: String, maybeTitle: Option[String])(implicit request: Request[_], messages: play.api.i18n.Messages)
     <div class="videoWrapper">
         <iframe
         data-dnt-embed
@@ -24,12 +26,10 @@
         data-dnt-default-buttontext-left="@Messages("hts.global.dnt.default.button.with.title.text.left")"
         data-dnt-default-buttontext-right="@Messages("hts.global.dnt.default.button.with.title.text.right")"
         @maybeTitle.map{title => title="@title" }
-        style="border:0;"
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         <noscript>
             <iframe
             src="https://www.youtube.com/embed/@{embedCode}"
-            style="border:0;"
             allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </noscript>
     </div>

--- a/app/uk/gov/hmrc/helptosavefrontend/views/helpers/youtube_embed.scala.html
+++ b/app/uk/gov/hmrc/helptosavefrontend/views/helpers/youtube_embed.scala.html
@@ -14,8 +14,6 @@
  * limitations under the License.
  *@
 
-@import views.html.helper.CSPNonce
-
 @(embedCode: String, maybeTitle: Option[String])(implicit request: Request[_], messages: play.api.i18n.Messages)
     <div class="videoWrapper">
         <iframe

--- a/app/uk/gov/hmrc/helptosavefrontend/views/helpers/youtube_embed.scala.html
+++ b/app/uk/gov/hmrc/helptosavefrontend/views/helpers/youtube_embed.scala.html
@@ -24,12 +24,10 @@
         data-dnt-default-buttontext-left="@Messages("hts.global.dnt.default.button.with.title.text.left")"
         data-dnt-default-buttontext-right="@Messages("hts.global.dnt.default.button.with.title.text.right")"
         @maybeTitle.map{title => title="@title" }
-        style="border:0;"
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         <noscript>
             <iframe
             src="https://www.youtube.com/embed/@{embedCode}"
-            style="border:0;"
             allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </noscript>
     </div>

--- a/app/uk/gov/hmrc/helptosavefrontend/views/helpinformation/savings_explained.scala.html
+++ b/app/uk/gov/hmrc/helptosavefrontend/views/helpinformation/savings_explained.scala.html
@@ -17,6 +17,6 @@
 @import uk.gov.hmrc.helptosavefrontend.views.html.helpers._
 @import uk.gov.hmrc.helptosavefrontend.config.FrontendAppConfig
 
-@()(implicit messages: play.api.i18n.Messages, appConfig: FrontendAppConfig, request: Request[_])
+@()(implicit messages: play.api.i18n.Messages, appConfig: FrontendAppConfig)
 
 @youtube_embed(appConfig.youtubeSavingsExplained, Some(Messages("hts.help-information.section.how-account-works.s1.title")))

--- a/app/uk/gov/hmrc/helptosavefrontend/views/helpinformation/savings_explained.scala.html
+++ b/app/uk/gov/hmrc/helptosavefrontend/views/helpinformation/savings_explained.scala.html
@@ -17,6 +17,6 @@
 @import uk.gov.hmrc.helptosavefrontend.views.html.helpers._
 @import uk.gov.hmrc.helptosavefrontend.config.FrontendAppConfig
 
-@()(implicit messages: play.api.i18n.Messages, appConfig: FrontendAppConfig)
+@()(implicit messages: play.api.i18n.Messages, appConfig: FrontendAppConfig, request: Request[_])
 
 @youtube_embed(appConfig.youtubeSavingsExplained, Some(Messages("hts.help-information.section.how-account-works.s1.title")))

--- a/app/uk/gov/hmrc/helptosavefrontend/views/layout.scala.html
+++ b/app/uk/gov/hmrc/helptosavefrontend/views/layout.scala.html
@@ -19,6 +19,7 @@
 @import uk.gov.hmrc.helptosavefrontend.config.FrontendAppConfig
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.helptosavefrontend.models.HtsContext
+@import views.html.helper.CSPNonce
 
 @this(
     hmrcLayout: HmrcLayout,
@@ -53,13 +54,13 @@
       timeout = Some(appConfig.TimeoutConfig.timeoutSeconds)
     )
   }
-  <link rel="stylesheet" href='@routes.Assets.versioned("stylesheets/application.css")' />
-  @extraMeta.getOrElse(Html(""))
+@Html(s"""<link rel="stylesheet" media="screen" href="${routes.Assets.versioned("stylesheets/application.css")}" ${CSPNonce.attr}>""")
+@extraMeta.getOrElse(Html(""))
 }
 
 @scripts = {
-  <script src='@routes.Assets.versioned("javascripts/do-not-track.js")'></script>
-  <script>
+  @Html(s"""<script src="${routes.Assets.versioned("javascripts/do-not-track.js")}" ${CSPNonce.attr}></script>""")
+  <script @CSPNonce.attr>
           const DoNotTrackYouTube = new GOVUK.DoNotTrackYouTube();
           DoNotTrackYouTube.init()
   </script>
@@ -92,9 +93,10 @@
   isWelshTranslationAvailable = true,
   displayHmrcBanner = false,
   signOutUrl = if(enableSignOutLink) Some(appConfig.signOutUrl) else None,
-  additionalHeadBlock = Some(hmrcHead(headBlock = Some(head))),
+  additionalHeadBlock = Some(hmrcHead(nonce = CSPNonce.get, headBlock = Some(head))),
   beforeContentBlock = Some(beforeContentBlock),
   serviceName = Some(serviceName),
   phaseBanner = None,
-  additionalScriptsBlock = Some(scripts)
+  additionalScriptsBlock = Some(scripts),
+  nonce = CSPNonce.get
 )(content)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -22,7 +22,7 @@ play.filters.enabled += play.filters.csp.CSPFilter
 # Default strict CSP from https://www.playframework.com/documentation/2.8.x/CspFilter#Default-CSP-Policy
 # with an SHA hash to allow the Javascript-detection inline script from govuk-frontend:
 # https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#if-your-javascript-is-not-working-properly
-play.filters.csp.directives.script-src = ${play.filters.csp.nonce.pattern} "'self' 'unsafe-inline' 'strict-dynamic' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' https://www.googletagmanager.com https://tagmanager.google.com https://www.youtube.com https://www.youtube-nocookie.com *.optimizely.com https: http:"
+play.filters.csp.directives.script-src = ${play.filters.csp.nonce.pattern} "'self' 'unsafe-inline' 'strict-dynamic' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' https://www.googletagmanager.com https://tagmanager.google.com https://www.youtube.com https://www.youtube-nocookie.com https: http:"
 play.filters.csp.directives.style-src = ${play.filters.csp.nonce.pattern} "'self' https://tagmanager.google.com https://fonts.googleapis.com;"
 play.filters.csp.directives.img-src = "'self' img.youtube.com i3.ytimg.com https://ssl.gstatic.com www.gstatic.com https://www.google-analytics.com data https//region1.google-analytics.com https://region1.analytics.google.com https://*.google-analytics.com https://*.analytics.google.com data:"
 play.filters.csp.directives.font-src = "'self' https://ssl.gstatic.com www.gstatic.com https://fonts.gstatic.com https://fonts.googleapis.com;"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -17,9 +17,17 @@ include "frontend.conf"
 appName = "help-to-save-frontend"
 play.http.router = prod.Routes
 play.i18n.langs = ["en","cy"]
+play.filters.enabled += play.filters.csp.CSPFilter
 
-# to learn why this was included: /display/TEC/2016/03/14/Setting+Security+Headers+in+frontend+services
-play.filters.csp.CSPFilter = "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 localhost:9250 http://localhost:12345 www.googletagmanager.com www.google-analytics.com www.youtube.com www.youtube-nocookie.com *.optimizely.com data:; img-src 'self' www.google-analytics.com *.googleusercontent.com img.youtube.com i3.ytimg.com"
+# Default strict CSP from https://www.playframework.com/documentation/2.8.x/CspFilter#Default-CSP-Policy
+# with an SHA hash to allow the Javascript-detection inline script from govuk-frontend:
+# https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#if-your-javascript-is-not-working-properly
+play.filters.csp.directives.script-src = ${play.filters.csp.nonce.pattern} "'self' 'unsafe-inline' 'strict-dynamic' http://localhost:7000 https://www.googletagmanager.com https://tagmanager.google.com https://www.youtube.com https://www.youtube-nocookie.com *.optimizely.com https: http:"
+play.filters.csp.directives.style-src = ${play.filters.csp.nonce.pattern} "'self' https://tagmanager.google.com https://fonts.googleapis.com;"
+img-src = "'self' img.youtube.com i3.ytimg.com https://ssl.gstatic.com www.gstatic.com https://www.google-analytics.com data https//region1.google-analytics.com https://region1.analytics.google.com https://*.google-analytics.com https://*.analytics.google.com data:"
+font-src = "https://ssl.gstatic.com www.gstatic.com https://fonts.gstatic.com https://fonts.googleapis.com;"
+connect-src = "https//region1.google-analytics.com https://region1.analytics.google.com https://*.google-analytics.com https://*.analytics.google.com;"
+frame-src = "'self' https://www.youtube.com https://www.youtube-nocookie.com https://www.googletagmanager.com;"
 
 # An ApplicationLoader that uses Guice to bootstrap the application.
 play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -24,7 +24,7 @@ play.filters.enabled += play.filters.csp.CSPFilter
 # https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#if-your-javascript-is-not-working-properly
 play.filters.csp.directives.script-src = ${play.filters.csp.nonce.pattern} "'self' 'unsafe-inline' 'strict-dynamic' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' https://www.googletagmanager.com https://tagmanager.google.com https://www.youtube.com https://www.youtube-nocookie.com https: http:"
 play.filters.csp.directives.style-src = ${play.filters.csp.nonce.pattern} "'self' https://tagmanager.google.com https://fonts.googleapis.com;"
-play.filters.csp.directives.img-src = "'self' img.youtube.com i3.ytimg.com https://ssl.gstatic.com www.gstatic.com https://www.google-analytics.com data https//region1.google-analytics.com https://region1.analytics.google.com https://*.google-analytics.com https://*.analytics.google.com data:"
+play.filters.csp.directives.img-src = "'self' img.youtube.com i3.ytimg.com https://i.ytimg.com https://ssl.gstatic.com www.gstatic.com https://www.google-analytics.com data https//region1.google-analytics.com https://region1.analytics.google.com https://*.google-analytics.com https://*.analytics.google.com data:"
 play.filters.csp.directives.font-src = "'self' https://ssl.gstatic.com www.gstatic.com https://fonts.gstatic.com https://fonts.googleapis.com;"
 play.filters.csp.directives.connect-src = "https//region1.google-analytics.com https://region1.analytics.google.com https://*.google-analytics.com https://*.analytics.google.com;"
 play.filters.csp.directives.frame-src = "'self' https://www.youtube.com https://www.youtube-nocookie.com https://www.googletagmanager.com;"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -24,10 +24,10 @@ play.filters.enabled += play.filters.csp.CSPFilter
 # https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#if-your-javascript-is-not-working-properly
 play.filters.csp.directives.script-src = ${play.filters.csp.nonce.pattern} "'self' 'unsafe-inline' 'strict-dynamic' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' https://www.googletagmanager.com https://tagmanager.google.com https://www.youtube.com https://www.youtube-nocookie.com *.optimizely.com https: http:"
 play.filters.csp.directives.style-src = ${play.filters.csp.nonce.pattern} "'self' https://tagmanager.google.com https://fonts.googleapis.com;"
-img-src = "'self' img.youtube.com i3.ytimg.com https://ssl.gstatic.com www.gstatic.com https://www.google-analytics.com data https//region1.google-analytics.com https://region1.analytics.google.com https://*.google-analytics.com https://*.analytics.google.com data:"
-font-src = "https://ssl.gstatic.com www.gstatic.com https://fonts.gstatic.com https://fonts.googleapis.com;"
-connect-src = "https//region1.google-analytics.com https://region1.analytics.google.com https://*.google-analytics.com https://*.analytics.google.com;"
-frame-src = "'self' https://www.youtube.com https://www.youtube-nocookie.com https://www.googletagmanager.com;"
+play.filters.csp.directives.img-src = "'self' img.youtube.com i3.ytimg.com https://ssl.gstatic.com www.gstatic.com https://www.google-analytics.com data https//region1.google-analytics.com https://region1.analytics.google.com https://*.google-analytics.com https://*.analytics.google.com data:"
+play.filters.csp.directives.font-src = "'self' https://ssl.gstatic.com www.gstatic.com https://fonts.gstatic.com https://fonts.googleapis.com;"
+play.filters.csp.directives.connect-src = "https//region1.google-analytics.com https://region1.analytics.google.com https://*.google-analytics.com https://*.analytics.google.com;"
+play.filters.csp.directives.frame-src = "'self' https://www.youtube.com https://www.youtube-nocookie.com https://www.googletagmanager.com;"
 
 # An ApplicationLoader that uses Guice to bootstrap the application.
 play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -22,7 +22,7 @@ play.filters.enabled += play.filters.csp.CSPFilter
 # Default strict CSP from https://www.playframework.com/documentation/2.8.x/CspFilter#Default-CSP-Policy
 # with an SHA hash to allow the Javascript-detection inline script from govuk-frontend:
 # https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#if-your-javascript-is-not-working-properly
-play.filters.csp.directives.script-src = ${play.filters.csp.nonce.pattern} "'self' 'unsafe-inline' 'strict-dynamic' http://localhost:7000 https://www.googletagmanager.com https://tagmanager.google.com https://www.youtube.com https://www.youtube-nocookie.com *.optimizely.com https: http:"
+play.filters.csp.directives.script-src = ${play.filters.csp.nonce.pattern} "'self' 'unsafe-inline' 'strict-dynamic' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' https://www.googletagmanager.com https://tagmanager.google.com https://www.youtube.com https://www.youtube-nocookie.com *.optimizely.com https: http:"
 play.filters.csp.directives.style-src = ${play.filters.csp.nonce.pattern} "'self' https://tagmanager.google.com https://fonts.googleapis.com;"
 img-src = "'self' img.youtube.com i3.ytimg.com https://ssl.gstatic.com www.gstatic.com https://www.google-analytics.com data https//region1.google-analytics.com https://region1.analytics.google.com https://*.google-analytics.com https://*.analytics.google.com data:"
 font-src = "https://ssl.gstatic.com www.gstatic.com https://fonts.gstatic.com https://fonts.googleapis.com;"


### PR DESCRIPTION
This is a proposed strict CSP for all environments, if merged we should remove `play.filters.headers.contentSecurityPolicy.base64` config from app-config-staging and app-config-production (https://github.com/hmrc/app-config-production/blob/40cf2b3083cc6e6c9f0c6a858ab8da36a336263a/help-to-save-frontend.yaml#L51) to allow this to prevail. Merging this will not change anything in staging or production otherwise.