### PR TITLE
[DLS-7229] updated bootstrap backend to 5.25.0

### DIFF
--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -5,13 +5,7 @@
         <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
     </appender>
 
-    <logger name="uk.gov" level="INFO"/>
-    
-    <logger name="uk.gov.hmrc.audit.handler" level="WARN"/>
-
-    <root level="INFO">
+    <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
-
-
 </configuration>

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,10 +4,11 @@ object AppDependencies {
 
   val hmrc = "uk.gov.hmrc"
   val playVersion = "play-28"
+  val bootstrapBackendVersion = "5.25.0"
 
   val compile = Seq(
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"         % "0.68.0",
-    hmrc                %% "bootstrap-frontend-play-28" % "5.24.0",
+    hmrc                %% "bootstrap-frontend-play-28" % bootstrapBackendVersion,
     "com.github.kxbmap" %% "configs"                    % "0.4.4",
     "org.typelevel"     %% "cats-core"                  % "2.6.1",
     hmrc                %% "domain"                     % "6.2.0-play-28",
@@ -18,15 +19,15 @@ object AppDependencies {
   )
 
   val test = Seq(
-    hmrc                     %% "service-integration-test"    % "1.1.0-play-28"     % "test",
-    hmrc                     %% "stub-data-generator"         % "0.5.3"             % "test",
-    "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28"     % "0.68.0"            % "test",
-    "org.scalatestplus"      %% "scalatestplus-scalacheck"    % "3.1.0.0-RC2"       % "test",
-    "org.scalatestplus"      %% "scalatestplus-mockito"       % "1.0.0-M2"          % "test",
-    "org.scalamock"          %% "scalamock-scalatest-support" % "3.6.0"             % "test",
-    "com.miguno.akka"        %% "akka-mock-scheduler"         % "0.5.5"             % "test",
-    "uk.gov.hmrc"            %% "bootstrap-test-play-28"      % "5.24.0"            % "test",
-    "com.vladsch.flexmark"    % "flexmark-all"                % "0.35.10"           % "test"
+    hmrc                     %% "service-integration-test"    % "1.1.0-play-28"                    % "test",
+    hmrc                     %% "stub-data-generator"         % "0.5.3"                            % "test",
+    "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28"     % "0.68.0"                           % "test",
+    "org.scalatestplus"      %% "scalatestplus-scalacheck"    % "3.1.0.0-RC2"                      % "test",
+    "org.scalatestplus"      %% "scalatestplus-mockito"       % "1.0.0-M2"                         % "test",
+    "org.scalamock"          %% "scalamock-scalatest-support" % "3.6.0"                            % "test",
+    "com.miguno.akka"        %% "akka-mock-scheduler"         % "0.5.5"                            % "test",
+    "uk.gov.hmrc"            %% "bootstrap-test-play-28"      % bootstrapBackendVersion            % "test",
+    "com.vladsch.flexmark"    % "flexmark-all"                % "0.35.10"                          % "test"
   )
 
   def apply(): Seq[ModuleID] = compile ++ test


### PR DESCRIPTION
Bumped bootstrap backend up to latest 5.x.x version. 

[Ticket](https://github.com/hmrc/help-to-save-frontend/pull/1029)