### PR TITLE
DLS-6976 handle status 304

### DIFF
--- a/app/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveReminderConnector.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveReminderConnector.scala
@@ -81,13 +81,13 @@ class HelpToSaveReminderConnectorImpl @Inject() (http: HttpClient)(implicit fron
 
   private def handle[B](
     resF: Future[HttpResponse],
-    ifHTTP200: HttpResponse => Either[String, B],
+    ifHTTP200or404: HttpResponse => Either[String, B],
     description: => String
   )(implicit ec: ExecutionContext) =
     for {
       response <- toEitherT(description, resF)
       result <- response.status match {
-        case Status.OK | Status.NOT_FOUND => EitherT.fromEither[Future](ifHTTP200(response))
+        case Status.OK | Status.NOT_FOUND => EitherT.fromEither[Future](ifHTTP200or404(response))
         case _ => EitherT.leftT[Future, B](s"Call to $description came back with status ${response.status}. Body was ${response.body}")
       }
     } yield result

--- a/app/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveReminderConnector.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveReminderConnector.scala
@@ -57,8 +57,6 @@ class HelpToSaveReminderConnectorImpl @Inject() (http: HttpClient)(implicit fron
 
   private val emailUpdateHtsReminderURL = s"$htsReminderURL/help-to-save-reminder/update-htsuser-email"
 
-  private val emptyQueryParameters: Map[String, String] = Map.empty[String, String]
-
   override def updateHtsUser(htsUser: HtsUserSchedule)(implicit hc: HeaderCarrier, ec: ExecutionContext): Result[HtsUserSchedule] =
     handle(http.post(updateHtsReminderURL, htsUser), _.parseJSON[HtsUserSchedule](), "update htsUser")
 

--- a/app/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveReminderConnector.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveReminderConnector.scala
@@ -60,10 +60,10 @@ class HelpToSaveReminderConnectorImpl @Inject() (http: HttpClient)(implicit fron
   private val emptyQueryParameters: Map[String, String] = Map.empty[String, String]
 
   override def updateHtsUser(htsUser: HtsUserSchedule)(implicit hc: HeaderCarrier, ec: ExecutionContext): Result[HtsUserSchedule] =
-    handlePost(updateHtsReminderURL, htsUser, _.parseJSON[HtsUserSchedule](), "update htsUser", identity)
+    handle(http.post(updateHtsReminderURL, htsUser), _.parseJSON[HtsUserSchedule](), "update htsUser", identity)
 
   override def getHtsUser(nino: String)(implicit hc: HeaderCarrier, ex: ExecutionContext): Result[HtsUserSchedule] =
-    handleGet(getHtsReminderUserURL(nino), emptyQueryParameters, _.parseJSON[HtsUserSchedule](), "get hts user", identity)
+    handle(http.get(getHtsReminderUserURL(nino)), _.parseJSON[HtsUserSchedule](), "get hts user", identity)
 
   override def cancelHtsUserReminders(
     cancelHtsUserReminder: CancelHtsUserReminder
@@ -79,24 +79,6 @@ class HelpToSaveReminderConnectorImpl @Inject() (http: HttpClient)(implicit fron
         case _ => EitherT.leftT[Future, Unit](s"Call to 'cancel reminder' came back with status ${response.status}. Body was ${response.body}")
       }
     } yield result
-
-  private def handlePost[A, B](
-    url: String,
-    body: HtsUserSchedule,
-    ifHTTP200: HttpResponse => Either[B, A],
-    description: => String,
-    toError: String => B
-  )(implicit hc: HeaderCarrier, ec: ExecutionContext): EitherT[Future, B, A] =
-    handle(http.post(url, body), ifHTTP200, description, toError)
-
-  private def handleGet[A, B](
-    url: String,
-    queryParameters: Map[String, String],
-    ifHTTP200: HttpResponse => Either[B, A],
-    description: => String,
-    toError: String => B
-  )(implicit hc: HeaderCarrier, ec: ExecutionContext): EitherT[Future, B, A] =
-    handle(http.get(url, queryParameters), ifHTTP200, description, toError)
 
   private def handle[A, B](
     resF: Future[HttpResponse],
@@ -121,15 +103,6 @@ class HelpToSaveReminderConnectorImpl @Inject() (http: HttpClient)(implicit fron
   override def updateReminderEmail(
     updateReminderEmail: UpdateReminderEmail
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): Result[Unit] =
-    handlePostEmailUpdate(emailUpdateHtsReminderURL, updateReminderEmail, _ => Right(()), "update email", identity)
-
-  private def handlePostEmailUpdate[A, B](
-    url: String,
-    body: UpdateReminderEmail,
-    ifHTTP200: HttpResponse => Either[B, A],
-    description: => String,
-    toError: String => B
-  )(implicit hc: HeaderCarrier, ec: ExecutionContext): EitherT[Future, B, A] =
-    handle(http.post(url, body), ifHTTP200, description, toError)
+    handle(http.post(emailUpdateHtsReminderURL, updateReminderEmail), _ => Right(()), "update email", identity)
 
 }

--- a/test/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveReminderConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveReminderConnectorSpec.scala
@@ -93,12 +93,23 @@ class HelpToSaveReminderConnectorSpec
     val cancelHtsUserReminder = CancelHtsUserReminder(ninoNew)
 
     "return http response as it is to the caller" in {
-      val response =
-        HttpResponse(200, emptyBody)
+      val response = HttpResponse(200, emptyBody)
       mockPost(cancelHtsReminderURL, Map.empty, cancelHtsUserReminder)(Some(response))
       val result = connector.cancelHtsUserReminders(cancelHtsUserReminder)
       await(result.value) should equal(Right(()))
 
+    }
+    "return http response as it is to the caller when not modified" in {
+      val response = HttpResponse(304, emptyBody)
+      mockPost(cancelHtsReminderURL, Map.empty, cancelHtsUserReminder)(Some(response))
+      val result = connector.cancelHtsUserReminders(cancelHtsUserReminder)
+      await(result.value) should equal(Right(()))
+    }
+    "fail when unexpected response received" in {
+      val response = HttpResponse(400, emptyBody)
+      mockPost(cancelHtsReminderURL, Map.empty, cancelHtsUserReminder)(Some(response))
+      val result = connector.cancelHtsUserReminders(cancelHtsUserReminder)
+      await(result.value).isLeft should equal(true)
     }
   }
 


### PR DESCRIPTION
[Ticket](https://jira.tools.tax.service.gov.uk/browse/DLS-6976)

Contrary to what might be seen in the ticket description, the problem is caused by the error 304 coming from HTS-reminder, not 404.

Here's a link to the endpoint we're calling:

https://github.com/hmrc/help-to-save-reminder/blob/6a50033d37fe2c63ca33aa2c3f0a7572645f2e04/app/uk/gov/hmrc/helptosavereminder/controllers/HtsUserUpdateController.scala#L83