### PR TITLE
DLS-6358 Fix scaladoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,8 @@ lazy val commonSettings = Seq(
   scalacOptions ++= Seq(
     "-Xcheckinit",
     "-feature",
-  )
+  ),
+  Compile / scalacOptions -= "utf8",
 ) ++
   scalaSettings ++ defaultSettings() ++ scoverageSettings ++ playSettings
 


### PR DESCRIPTION
Common fix to remove a spurrious utf8 option added by the wartremover