### PR TITLE
DLS-10958 | Add personal tax enrolment check as part of nino authorisation

### DIFF
--- a/app/uk/gov/hmrc/helptosavefrontend/config/FrontendAppConfig.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/config/FrontendAppConfig.scala
@@ -103,6 +103,10 @@ class FrontendAppConfig @Inject() (servicesConfig: ServicesConfig) {
   val accountHolderContinueURL: String = s"$helpToSaveFrontendUrl/account-home/email-confirmed-callback"
 
   val nsiManageAccountUrl: String = getUrlFor("nsi.manage-account")
+
+  val protectTaxInfoUrl: String =
+    s"${getUrlFor("protect-tax-info")}?redirectUrl=${urlEncode(getUrlFor("help-to-save-frontend"))}"
+
   val nsiPayInUrl: String = getUrlFor("nsi.pay-in")
 
   val govUkURL: String = servicesConfig.getString("gov-uk.url.base")

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -142,6 +142,10 @@ microservice {
       url = "https://www.tax.service.gov.uk"
     }
 
+    protect-tax-info {
+      url = "http://localhost:7750/protect-tax-info"
+    }
+
     identity-verification-journey-result {
       host = localhost
       port = 9938

--- a/test/uk/gov/hmrc/helptosavefrontend/auth/HelpToSaveAuthSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/auth/HelpToSaveAuthSpec.scala
@@ -89,7 +89,7 @@ class HelpToSaveAuthSpec extends ControllerSpecWithGuiceApp with AuthSupport {
     }
 
     "filter out empty emails" in {
-      val retrieval = new ~(Some(name), Option("")) and Option(dob) and Some(itmpName) and itmpDob and Some(itmpAddress) and mockedNINORetrieval
+      val retrieval = new ~(Some(name), Option("")) and Option(dob) and Some(itmpName) and itmpDob and Some(itmpAddress) and mockedNINORetrieval and enrolmentsWithMatchingNino
 
       mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(retrieval)
 
@@ -109,7 +109,7 @@ class HelpToSaveAuthSpec extends ControllerSpecWithGuiceApp with AuthSupport {
       def retrieval(address: ItmpAddress) =
         new ~(Some(Name(None, None)), email) and Option(dob) and Some(ItmpName(None, None, None)) and itmpDob and Some(
           address
-        ) and mockedNINORetrieval
+        ) and mockedNINORetrieval and enrolmentsWithMatchingNino
 
       List(
         ItmpAddress(None, None, None, None, None, Some("postcode"), None, None),

--- a/test/uk/gov/hmrc/helptosavefrontend/connectors/EmailVerificationConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/connectors/EmailVerificationConnectorSpec.scala
@@ -20,19 +20,18 @@ import org.mockito.IdiomaticMockito
 import org.scalatest.EitherValues
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import play.api.{Application, Configuration}
-import play.api.libs.json._
 import play.api.http.Status
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json._
+import play.api.{Application, Configuration}
 import uk.gov.hmrc.helptosavefrontend.config.FrontendAppConfig
-import uk.gov.hmrc.helptosavefrontend.controllers.{ControllerSpecBase, ControllerSpecWithGuiceApp}
+import uk.gov.hmrc.helptosavefrontend.controllers.ControllerSpecBase
 import uk.gov.hmrc.helptosavefrontend.models.email.VerifyEmailError.OtherError
 import uk.gov.hmrc.helptosavefrontend.models.email.{EmailVerificationRequest, VerifyEmailError}
 import uk.gov.hmrc.helptosavefrontend.util.{Crypto, Email, NINO, NINOLogMessageTransformer, TestNINOLogMessageTransformer, WireMockMethods}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.http.test.WireMockSupport
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 
-import uk.gov.hmrc.http.HttpClient
 import scala.concurrent.ExecutionContext
 
 class EmailVerificationConnectorSpec

--- a/test/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveConnectorSpec.scala
@@ -23,10 +23,10 @@ import org.scalatest.EitherValues
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.{Application, Configuration}
 import play.api.libs.json._
+import play.api.{Application, Configuration}
 import uk.gov.hmrc.helptosavefrontend.connectors.HelpToSaveConnectorImpl.GetEmailResponse
-import uk.gov.hmrc.helptosavefrontend.controllers.{ControllerSpecBase, ControllerSpecWithGuiceApp}
+import uk.gov.hmrc.helptosavefrontend.controllers.ControllerSpecBase
 import uk.gov.hmrc.helptosavefrontend.models.TestData.UserData.validNSIPayload
 import uk.gov.hmrc.helptosavefrontend.models._
 import uk.gov.hmrc.helptosavefrontend.models.account.{Account, AccountNumber}
@@ -35,12 +35,12 @@ import uk.gov.hmrc.helptosavefrontend.models.eligibility.{EligibilityCheckRespon
 import uk.gov.hmrc.helptosavefrontend.models.register.CreateAccountRequest
 import uk.gov.hmrc.helptosavefrontend.services.HelpToSaveServiceImpl.SubmissionSuccess
 import uk.gov.hmrc.helptosavefrontend.util.WireMockMethods
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.http.test.WireMockSupport
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
 import java.time.LocalDate
 import java.util.{Base64, UUID}
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 // scalastyle:off magic.number
 class HelpToSaveConnectorSpec

--- a/test/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveReminderConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/connectors/HelpToSaveReminderConnectorSpec.scala
@@ -21,14 +21,14 @@ import org.mockito.IdiomaticMockito
 import org.scalatest.EitherValues
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.{Application, Configuration}
 import play.api.libs.json._
+import play.api.{Application, Configuration}
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.helptosavefrontend.controllers.{ControllerSpecBase, ControllerSpecWithGuiceApp}
+import uk.gov.hmrc.helptosavefrontend.controllers.ControllerSpecBase
 import uk.gov.hmrc.helptosavefrontend.models.reminder.{CancelHtsUserReminder, HtsUserSchedule, UpdateReminderEmail}
 import uk.gov.hmrc.helptosavefrontend.util.WireMockMethods
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.http.test.WireMockSupport
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext

--- a/test/uk/gov/hmrc/helptosavefrontend/connectors/IvConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/connectors/IvConnectorSpec.scala
@@ -22,15 +22,15 @@ import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.{Application, Configuration}
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
-import uk.gov.hmrc.helptosavefrontend.controllers.{ControllerSpecBase, ControllerSpecWithGuiceApp}
+import play.api.{Application, Configuration}
+import uk.gov.hmrc.helptosavefrontend.controllers.ControllerSpecBase
 import uk.gov.hmrc.helptosavefrontend.models.iv.IvSuccessResponse.Success
 import uk.gov.hmrc.helptosavefrontend.models.iv.{IvErrorResponse, IvUnexpectedResponse, JourneyId}
 import uk.gov.hmrc.helptosavefrontend.util.WireMockMethods
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
-import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.http.test.WireMockSupport
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
 import java.util.UUID
 import scala.concurrent.ExecutionContext

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/BankAccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/BankAccountControllerSpec.scala
@@ -69,7 +69,7 @@ class BankAccountControllerSpec
 
       "handle the request and display the page" in {
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(Some(HTSSession(Some(Right(randomEligibleWithUserInfo(validUserInfo))), None, None)))
@@ -85,7 +85,7 @@ class BankAccountControllerSpec
 
       "display the page with correct Back link when they came from applySavingsReminders page" in {
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(Some(HTSSession(Some(Right(randomEligibleWithUserInfo(validUserInfo))), None, None)))
@@ -101,7 +101,7 @@ class BankAccountControllerSpec
 
       "display the page with correct Back link when they came from emailVerified page" in {
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(Some(HTSSession(Some(Right(randomEligibleWithUserInfo(validUserInfo))), None, Some("pendingEmail"))))
@@ -117,7 +117,7 @@ class BankAccountControllerSpec
 
       "display the page with correct Back link when they came from check details page" in {
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(
@@ -148,7 +148,7 @@ class BankAccountControllerSpec
 
       "send already stored bank details in the session back to the UI" in {
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(
@@ -196,7 +196,7 @@ class BankAccountControllerSpec
       "handle form errors during submit" in {
         val eligibilityResult = Some(Right(randomEligibleWithUserInfo(validUserInfo)))
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(HTSSession(eligibilityResult, None, None))))
 
@@ -214,7 +214,7 @@ class BankAccountControllerSpec
       "handle cases when the backend bank details check mark the details as valid" in {
         val eligibilityResult = Some(Right(randomEligibleWithUserInfo(validUserInfo)))
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(HTSSession(eligibilityResult, None, None))))
         mockValidateBankDetails(ValidateBankDetailsRequest(nino, "123456", "12345678"))(
@@ -231,7 +231,7 @@ class BankAccountControllerSpec
       "handle cases when the backend bank details check mark the sort code as non-existent" in {
         val eligibilityResult = Some(Right(randomEligibleWithUserInfo(validUserInfo)))
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(HTSSession(eligibilityResult, None, None))))
         mockValidateBankDetails(ValidateBankDetailsRequest(nino, "123456", "12345678"))(
@@ -249,7 +249,7 @@ class BankAccountControllerSpec
 
         val eligibilityResult = Some(Right(randomEligibleWithUserInfo(validUserInfo)))
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(HTSSession(eligibilityResult, None, None))))
         mockValidateBankDetails(ValidateBankDetailsRequest(nino, "123456", "12345678"))(
@@ -275,7 +275,7 @@ class BankAccountControllerSpec
 
         val eligibilityResult = Some(Right(randomEligibleWithUserInfo(validUserInfo)))
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(HTSSession(eligibilityResult, None, None))))
         mockValidateBankDetails(ValidateBankDetailsRequest(nino, "123456", "12345678"))(
@@ -297,7 +297,7 @@ class BankAccountControllerSpec
       }
 
       "handle the case when the request comes from already enrolled user" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
 
         val result = doRequest()
@@ -308,7 +308,7 @@ class BankAccountControllerSpec
 
   private def doCommonChecks(doRequest: () => Future[Result]): Unit = {
     "redirect user to eligibility checks if there is no session found" in {
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
       mockSessionStoreGet(Right(None))
 
@@ -318,7 +318,7 @@ class BankAccountControllerSpec
     }
 
     "redirect user to eligibility checks if there is a session but no eligibility result found in the session" in {
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
       mockSessionStoreGet(Right(Some(HTSSession(None, None, None))))
 
@@ -329,7 +329,7 @@ class BankAccountControllerSpec
 
     "show user an in-eligible page if the session is found but user is not eligible" in {
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
       mockSessionStoreGet(Right(Some(HTSSession(Some(Left(randomIneligibility())), None, None))))
 
@@ -339,7 +339,7 @@ class BankAccountControllerSpec
 
     "show user an error page if the session is found but user is not eligible and in-eligibility reason can't be parsed" in {
       val eligibilityCheckResult = randomIneligibility().value.eligibilityCheckResult.copy(reasonCode = 999)
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
       mockSessionStoreGet(
         Right(

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/EligibilityCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/EligibilityCheckControllerSpec.scala
@@ -25,6 +25,7 @@ import play.api.mvc.{Result => PlayResult}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.retrieve.{ItmpAddress, ItmpName, Name, ~}
+import uk.gov.hmrc.auth.core.syntax.retrieved.authSyntaxForRetrieved
 import uk.gov.hmrc.helptosavefrontend.config.FrontendAppConfig
 import uk.gov.hmrc.helptosavefrontend.models.HtsAuth.AuthWithCL200
 import uk.gov.hmrc.helptosavefrontend.models.TestData.Eligibility._
@@ -83,7 +84,7 @@ class EligibilityCheckControllerSpec
       behave like commonEnrolmentAndSessionBehaviour(() => getIsEligible())
 
       "show the you are eligible page if session data indicates that they are eligible" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(
@@ -108,7 +109,7 @@ class EligibilityCheckControllerSpec
       }
 
       "redirect to the you are not eligible page if session data indicates that they are not eligible" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(HTSSession(Some(Left(randomIneligibility())), None, None))))
 
@@ -118,7 +119,7 @@ class EligibilityCheckControllerSpec
       }
 
       "redirect to check eligibility if the session data indicates they have not done the eligibility checks yet" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(HTSSession(None, None, None))))
 
@@ -135,7 +136,7 @@ class EligibilityCheckControllerSpec
       behave like commonEnrolmentAndSessionBehaviour(() => getIsNotEligible())
 
       "show the you are not eligible page if session data indicates that they are not eligible" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(HTSSession(Some(Left(randomIneligibility())), None, None))))
 
@@ -145,7 +146,7 @@ class EligibilityCheckControllerSpec
       }
 
       "redirect to the you are eligible page if session data indicates that they are eligible" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(Some(HTSSession(Some(Right(randomEligibleWithUserInfo(validUserInfo))), None, None)))
@@ -157,7 +158,7 @@ class EligibilityCheckControllerSpec
       }
 
       "redirect to check eligibility if the session data indicates they have not done the eligibility checks yet" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(HTSSession(None, None, None))))
 
@@ -168,7 +169,7 @@ class EligibilityCheckControllerSpec
 
       "show an error if the ineligibility reason cannot be parsed" in {
         val eligibilityCheckResult = randomIneligibility().value.eligibilityCheckResult.copy(reasonCode = 999)
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(
@@ -194,7 +195,7 @@ class EligibilityCheckControllerSpec
 
       "display the uc threshold amount when it can be obtained from DES via the BE when the user is not eligible due to " +
         "reason: NotEntitledToWTCAndUCInsufficient (code 5)" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(HTSSession(Some(Left(notEntitledToWTCAndUCInsufficient())), None, None))))
 
@@ -208,7 +209,7 @@ class EligibilityCheckControllerSpec
 
       "not display the uc threshold amount when it cannot be obtained from DES when the user is not eligible due to " +
         "reason: NotEntitledToWTCAndUCInsufficient (code 5)" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(Some(HTSSession(Some(Left(notEntitledToWTCAndUCInsufficientWithNoThreshold())), None, None)))
@@ -224,7 +225,7 @@ class EligibilityCheckControllerSpec
 
       "display the uc threshold amount when it can be obtained from DES via the BE when the user is not eligible due to " +
         "reason: EntitledToWTCNoTCAndInsufficientUC | NotEntitledToWTCAndNoUC (code 4 | 9)" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(HTSSession(Some(Left(ineligibilityReason4or9())), None, None))))
 
@@ -238,7 +239,7 @@ class EligibilityCheckControllerSpec
 
       "not display the uc threshold amount when it cannot be obtained from DES when the user is not eligible due to " +
         "reason: EntitledToWTCNoTCAndInsufficientUC | NotEntitledToWTCAndNoUC (code 4 | 9)" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(HTSSession(Some(Left(ineligibilityReason4or9WithNoThreshold())), None, None))))
 
@@ -254,7 +255,9 @@ class EligibilityCheckControllerSpec
     "displaying the you think you're eligible page" must {
 
       "redirect to the eligibility check if there is no session data" in {
-        mockAuthWithNINORetrievalWithSuccess(uk.gov.hmrc.helptosavefrontend.models.HtsAuth.AuthWithCL200)(Some(nino))
+        mockAuthWithNINORetrievalWithSuccess(uk.gov.hmrc.helptosavefrontend.models.HtsAuth.AuthWithCL200)(
+          Some(nino) and enrolmentsWithMatchingNino
+        )
         mockSessionStoreGet(Right(None))
 
         val result = controller.getThinkYouAreEligiblePage(FakeRequest())
@@ -264,7 +267,9 @@ class EligibilityCheckControllerSpec
       }
 
       "show the you're eligible page if the session data indicates that the user is eligible" in {
-        mockAuthWithNINORetrievalWithSuccess(uk.gov.hmrc.helptosavefrontend.models.HtsAuth.AuthWithCL200)(Some(nino))
+        mockAuthWithNINORetrievalWithSuccess(uk.gov.hmrc.helptosavefrontend.models.HtsAuth.AuthWithCL200)(
+          Some(nino) and enrolmentsWithMatchingNino
+        )
         mockSessionStoreGet(
           Right(Some(HTSSession(Some(Right(randomEligibleWithUserInfo(validUserInfo))), None, None, None, None)))
         )
@@ -275,7 +280,9 @@ class EligibilityCheckControllerSpec
       }
 
       "show the correct page if the session data indicates that the user is ineligible" in {
-        mockAuthWithNINORetrievalWithSuccess(uk.gov.hmrc.helptosavefrontend.models.HtsAuth.AuthWithCL200)(Some(nino))
+        mockAuthWithNINORetrievalWithSuccess(uk.gov.hmrc.helptosavefrontend.models.HtsAuth.AuthWithCL200)(
+          Some(nino) and enrolmentsWithMatchingNino
+        )
         mockSessionStoreGet(Right(Some(HTSSession(Some(Left(randomIneligibility())), None, None, None, None))))
 
         val result = controller.getThinkYouAreEligiblePage(FakeRequest())
@@ -650,7 +657,7 @@ class EligibilityCheckControllerSpec
                 params.address
               )) {
             mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(
-              missingUserInfoRetrieval(params.name, params.surname, params.dob, params.address)
+              missingUserInfoRetrieval(params.name, params.surname, params.dob, params.address) and enrolmentsWithMatchingNino
             )
 
             val result: Future[PlayResult] = controller.getMissingInfoPage(FakeRequest())
@@ -682,7 +689,7 @@ class EligibilityCheckControllerSpec
       def doRequest(): Future[PlayResult] = controller.youAreEligibleSubmit(FakeRequest())
 
       "redirect to the give email page if the user has no email" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some("nino"))
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino) and enrolmentsWithMatchingNino)
         mockSessionStoreGet(
           Right(
             Some(HTSSession(Some(Right(randomEligibleWithUserInfo(validUserInfo.copy(email = None)))), None, None))
@@ -695,7 +702,7 @@ class EligibilityCheckControllerSpec
       }
 
       "redirect to the select email page if the user has an email" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some("nino"))
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino) and enrolmentsWithMatchingNino)
         mockSessionStoreGet(
           Right(
             Some(
@@ -714,7 +721,7 @@ class EligibilityCheckControllerSpec
       }
 
       "redirect to the check eligibility page if the user has no session" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some("nino"))
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino) and enrolmentsWithMatchingNino)
         mockSessionStoreGet(Right(None))
 
         val result = doRequest()
@@ -723,7 +730,7 @@ class EligibilityCheckControllerSpec
       }
 
       "redirect to the check eligibility page if the user has no eligiblity check result in their session" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some("nino"))
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino) and enrolmentsWithMatchingNino)
         mockSessionStoreGet(Right(Some(HTSSession(None, None, None))))
 
         val result = doRequest()
@@ -732,7 +739,7 @@ class EligibilityCheckControllerSpec
       }
 
       "redirect to the not eligible page if the user is not eligible" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some("nino"))
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino) and enrolmentsWithMatchingNino)
         mockSessionStoreGet(Right(Some(HTSSession(Some(Left(randomIneligibility())), None, None))))
 
         val result = doRequest()

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/EmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/EmailControllerSpec.scala
@@ -22,6 +22,7 @@ import org.mockito.ArgumentMatchersSugar.*
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.syntax.retrieved.authSyntaxForRetrieved
 import uk.gov.hmrc.helptosavefrontend.audit.HTSAuditor
 import uk.gov.hmrc.helptosavefrontend.connectors.EmailVerificationConnector
 import uk.gov.hmrc.helptosavefrontend.controllers.EmailControllerSpec.EligibleWithUserInfoOps
@@ -227,7 +228,9 @@ class EmailControllerSpec
 
       "handle DE users with an existing INVALID email from GG" in {
 
-        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(mockedRetrievalsWithEmail(Some("invalidEmail")))
+        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(
+          mockedRetrievalsWithEmail(Some("invalidEmail")) and enrolmentsWithMatchingNino
+        )
         mockSessionStoreGet(Right(Some(HTSSession(None, None, None))))
         mockEnrolmentCheck()(Right(Enrolled(true)))
         mockGetConfirmedEmail()(Right(None))
@@ -239,7 +242,9 @@ class EmailControllerSpec
       }
 
       "handle DE users with NO email from GG" in {
-        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(mockedRetrievalsWithEmail(None))
+        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(
+          mockedRetrievalsWithEmail(None) and enrolmentsWithMatchingNino
+        )
         mockSessionStoreGet(Right(Some(HTSSession(None, None, None))))
         mockEnrolmentCheck()(Right(Enrolled(true)))
         mockGetConfirmedEmail()(Right(None))
@@ -385,7 +390,9 @@ class EmailControllerSpec
 
       "handle DE users who submitted form with no new-email but with checked existing email" in {
         val session = HTSSession(None, None, Some(testEmail))
-        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(mockedRetrievalsWithEmail(None))
+        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(
+          mockedRetrievalsWithEmail(None) and enrolmentsWithMatchingNino
+        )
         mockSessionStoreGet(Right(Some(session)))
         mockEnrolmentCheck()(Right(Enrolled(true)))
         mockGetConfirmedEmail()(Right(None))
@@ -423,7 +430,9 @@ class EmailControllerSpec
       }
 
       "handle an existing account holder who submitted form with no new-email but with checked existing email" in {
-        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(mockedRetrievalsWithEmail(None))
+        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(
+          mockedRetrievalsWithEmail(None) and enrolmentsWithMatchingNino
+        )
         mockSessionStoreGet(Right(Some(HTSSession(None, None, Some(testEmail)))))
         mockEnrolmentCheck()(Right(Enrolled(true)))
         mockGetConfirmedEmail()(Right(Some(testEmail)))
@@ -538,7 +547,9 @@ class EmailControllerSpec
 
       "handle DE users who submitted form with no new-email but with checked existing email" in {
         val session = HTSSession(None, None, Some(testEmail))
-        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(mockedRetrievalsWithEmail(None))
+        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(
+          mockedRetrievalsWithEmail(None) and enrolmentsWithMatchingNino
+        )
         mockSessionStoreGet(Right(Some(session)))
         mockEnrolmentCheck()(Right(Enrolled(true)))
         mockGetConfirmedEmail()(Right(None))
@@ -576,7 +587,9 @@ class EmailControllerSpec
       }
 
       "handle an existing account holder who submitted form with no new-email but with checked existing email" in {
-        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(mockedRetrievalsWithEmail(None))
+        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(
+          mockedRetrievalsWithEmail(None) and enrolmentsWithMatchingNino
+        )
         mockSessionStoreGet(Right(Some(HTSSession(None, None, Some(testEmail)))))
         mockEnrolmentCheck()(Right(Enrolled(true)))
         mockGetConfirmedEmail()(Right(Some(testEmail)))
@@ -689,7 +702,9 @@ class EmailControllerSpec
 
       "DE users should not contain any Back link" in {
 
-        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(mockedRetrievalsWithEmail(None))
+        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(
+          mockedRetrievalsWithEmail(None) and enrolmentsWithMatchingNino
+        )
         mockSessionStoreGet(Right(Some(HTSSession(None, None, None))))
         mockEnrolmentCheck()(Right(Enrolled(true)))
         mockGetConfirmedEmail()(Right(None))
@@ -702,7 +717,9 @@ class EmailControllerSpec
 
       "handle DE users with an existing INVALID email from GG" in {
 
-        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(mockedRetrievalsWithEmail(Some("invalidEmail")))
+        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(
+          mockedRetrievalsWithEmail(Some("invalidEmail")) and enrolmentsWithMatchingNino
+        )
         mockSessionStoreGet(Right(None))
         mockEnrolmentCheck()(Right(Enrolled(true)))
         mockGetConfirmedEmail()(Right(None))
@@ -714,7 +731,9 @@ class EmailControllerSpec
       }
 
       "handle DE users with NO email from GG" in {
-        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(mockedRetrievalsWithEmail(None))
+        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(
+          mockedRetrievalsWithEmail(None) and enrolmentsWithMatchingNino
+        )
         mockSessionStoreGet(Right(None))
         mockEnrolmentCheck()(Right(Enrolled(true)))
         mockGetConfirmedEmail()(Right(None))
@@ -770,7 +789,7 @@ class EmailControllerSpec
 
       "handle Digital(new applicant) users with no valid session in mongo" in {
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(None))
         mockEnrolmentCheck()(Right(NotEnrolled))
 
@@ -781,7 +800,7 @@ class EmailControllerSpec
 
       "handle errors during session cache lookup in mongo" in {
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Left("unexpected error"))
 
         val result = giveEmailSubmit(email)
@@ -790,7 +809,7 @@ class EmailControllerSpec
 
       "handle Digital(new applicant) who submitted form with new email" in {
         val userInfo = randomEligibleWithUserInfo(validUserInfo)
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(
           Right(
             Some(
@@ -824,7 +843,7 @@ class EmailControllerSpec
 
       "handle existing digital account holders and redirect them to nsi" in {
         val userInfo = randomEligibleWithUserInfo(validUserInfo)
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(Some(HTSSession(Some(Right(userInfo)), None, Some(testEmail)))))
         mockEnrolmentCheck()(Right(Enrolled(true)))
         mockGetConfirmedEmail()(Right(Some("email")))
@@ -834,7 +853,7 @@ class EmailControllerSpec
       }
 
       "handle DE users - redirect to check eligibility if no existing session found" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(None))
         mockEnrolmentCheck()(Right(Enrolled(true)))
         mockGetConfirmedEmail()(Right(None))
@@ -845,7 +864,7 @@ class EmailControllerSpec
       }
 
       "handle DE user who submitted form with new-email" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(Some(HTSSession(None, None, None))))
         mockEnrolmentCheck()(Right(Enrolled(true)))
         mockGetConfirmedEmail()(Right(None))
@@ -857,7 +876,7 @@ class EmailControllerSpec
       }
 
       "handle DE user who submitted form with errors" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(Some(HTSSession(None, None, Some(testEmail)))))
         mockEnrolmentCheck()(Right(Enrolled(true)))
         mockGetConfirmedEmail()(Right(None))
@@ -1063,7 +1082,9 @@ class EmailControllerSpec
       "handle Digital users and return success result when there is no GG email" in {
         val newEmail = "new@email.com"
 
-        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(mockedRetrievalsWithEmail(None))
+        mockAuthWithAllRetrievalsWithSuccess(AuthWithCL200)(
+          mockedRetrievalsWithEmail(None) and enrolmentsWithMatchingNino
+        )
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockDecrypt("encrypted")(s"$nino#$newEmail")
         mockSessionStoreGet(Right(Some(HTSSession(Some(Right(eligibleWithUserInfo.withEmail(None))), None, None))))
@@ -1361,7 +1382,7 @@ class EmailControllerSpec
         csrfAddToken(controller.confirmEmailErrorTryLater)(fakeRequest)
 
       "handle Digital users who are already gone through eligibility checks" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(Some(HTSSession(None, None, None))))
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
 
@@ -1371,7 +1392,7 @@ class EmailControllerSpec
       }
 
       "handle DE users" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(Some(HTSSession(None, None, None))))
         mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
         mockGetConfirmedEmail()(Right(None))
@@ -1390,7 +1411,7 @@ class EmailControllerSpec
         )
 
       "handle Digital users and redirect to the email verify error page try later if there is no email for the user" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(
           Right(
             Some(HTSSession(Some(Right(randomEligibleWithUserInfo(validUserInfo.copy(email = None)))), None, None))
@@ -1405,7 +1426,7 @@ class EmailControllerSpec
 
       "handle Digital users and redirect to the emailConfirmed endpoint if there is an email for the user and the user selects to continue" in {
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(Some(HTSSession(Some(Right(eligibleWithValidUserInfo)), None, None))))
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockEncrypt(emailStr)(encryptedEmail)
@@ -1417,7 +1438,7 @@ class EmailControllerSpec
       }
 
       "handle Digital users and redirect to the info endpoint if there is an email for the user and the user selects not to continue" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(Some(HTSSession(Some(Right(eligibleWithValidUserInfo)), None, None))))
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
 
@@ -1427,7 +1448,7 @@ class EmailControllerSpec
       }
 
       "handle Digital users and show the verify email error page again if there is an error in the form" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(Some(HTSSession(Some(Right(eligibleWithValidUserInfo)), None, None))))
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
 
@@ -1437,7 +1458,7 @@ class EmailControllerSpec
       }
 
       "handle existing digital account holders and redirect them to nsi" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(Some(HTSSession(None, None, None))))
         mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
         mockGetConfirmedEmail()(Right(Some("email@email.com")))
@@ -1449,7 +1470,7 @@ class EmailControllerSpec
 
       "handle DE users and redirect to the emailConfirmed endpoint if there is an email for the user and the user selects to continue" in {
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(Some(HTSSession(None, Some(emailStr), None))))
         mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
         mockGetConfirmedEmail()(Right(None))
@@ -1468,7 +1489,7 @@ class EmailControllerSpec
       def getEmailConfirmed = csrfAddToken(controller.getEmailConfirmed)(fakeRequest)
 
       "handle Digital users and return the email verified page" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(Some(HTSSession(Some(Right(eligibleWithValidUserInfo)), Some("email"), None))))
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
 
@@ -1480,7 +1501,7 @@ class EmailControllerSpec
       "handle Digital users and redirect to check eligibility" when {
 
         "there is no session" in {
-          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
           mockSessionStoreGet(Right(None))
           mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
 
@@ -1494,7 +1515,7 @@ class EmailControllerSpec
       "handle Digital users and return an error" when {
 
         "there is no confirmed email in the session" in {
-          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
           mockSessionStoreGet(Right(Some(HTSSession(Some(Right(eligibleWithValidUserInfo)), None, None))))
           mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
 
@@ -1504,7 +1525,7 @@ class EmailControllerSpec
         }
 
         "there is no confirmed email in the session when there is no email for the user" in {
-          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
           mockSessionStoreGet(
             Right(
               Some(
@@ -1524,7 +1545,7 @@ class EmailControllerSpec
         }
 
         "the call to session cache fails" in {
-          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
           mockSessionStoreGet(Left(""))
 
           val result = getEmailConfirmed
@@ -1533,7 +1554,7 @@ class EmailControllerSpec
       }
 
       "handle DE users and return the give email page" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(Some(HTSSession(Some(Right(eligibleWithValidUserInfo)), Some("email"), None))))
         mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
         mockGetConfirmedEmail()(Right(None))
@@ -1551,7 +1572,7 @@ class EmailControllerSpec
         csrfAddToken(controller.getEmailUpdated())(fakeRequest)
 
       "show the email updated page otherwise" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(Some(HTSSession(Some(Right(eligibleWithValidUserInfo)), None, None))))
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
 
@@ -1567,7 +1588,7 @@ class EmailControllerSpec
 
       "handle Digital users and redirect to the getBankDetailsPage if bank details are not already in session" in {
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(Some(HTSSession(Some(Right(eligibleWithValidUserInfo)), None, None))))
         mockEnrolmentCheck()(Right(NotEnrolled))
 
@@ -1578,7 +1599,7 @@ class EmailControllerSpec
 
       "handle Digital users and redirect to the checkDetailsPage if the user is in the process of changing details" in {
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(
           Right(
             Some(
@@ -1603,7 +1624,7 @@ class EmailControllerSpec
 
       "handle Digital users and redirect to the eligibilityCheck if session doesnt contain eligibility result" in {
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(None))
         mockEnrolmentCheck()(Right(NotEnrolled))
 
@@ -1613,7 +1634,7 @@ class EmailControllerSpec
       }
 
       "handle existing digital account holders and redirect them to NSI" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(Some(HTSSession(Some(Right(eligibleWithValidUserInfo)), Some("email"), None))))
         mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
         mockGetConfirmedEmail()(Right(Some("email")))
@@ -1624,7 +1645,7 @@ class EmailControllerSpec
       }
 
       "handle DE users and redirect to the give email page" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockSessionStoreGet(Right(Some(HTSSession(Some(Right(eligibleWithValidUserInfo)), None, None))))
         mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
         mockGetConfirmedEmail()(Right(None))

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/EnrolmentAndEligibilityCheckBehaviour.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/EnrolmentAndEligibilityCheckBehaviour.scala
@@ -21,6 +21,7 @@ import cats.instances.future._
 import org.mockito.ArgumentMatchersSugar.*
 import play.api.mvc.Result
 import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.syntax.retrieved.authSyntaxForRetrieved
 import uk.gov.hmrc.helptosavefrontend.connectors.{HelpToSaveConnector, HelpToSaveReminderConnector}
 import uk.gov.hmrc.helptosavefrontend.forms.{BankDetails, SortCode}
 import uk.gov.hmrc.helptosavefrontend.models.HtsAuth.AuthWithCL200
@@ -96,8 +97,10 @@ trait EnrolmentAndEligibilityCheckBehaviour {
 
   def commonEnrolmentAndSessionBehaviour(
     getResult: () => Future[Result], // scalastyle:ignore method.length
-    mockSuccessfulAuth: () => Unit = () => mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval),
-    mockNoNINOAuth: () => Unit = () => mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(None),
+    mockSuccessfulAuth: () => Unit = () =>
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment),
+    mockNoNINOAuth: () => Unit = () =>
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(None and noPersonalTaxEnrolment),
     testRedirectOnNoSession: Boolean = true,
     testEnrolmentCheckError: Boolean = true,
     testRedirectOnNoEligibilityCheckResult: Boolean = true

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/IntroductionControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/IntroductionControllerSpec.scala
@@ -23,6 +23,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
 import uk.gov.hmrc.auth.core.retrieve.EmptyRetrieval
+import uk.gov.hmrc.auth.core.syntax.retrieved.authSyntaxForRetrieved
 import uk.gov.hmrc.helptosavefrontend.models.EnrolmentStatus.{Enrolled, NotEnrolled}
 import uk.gov.hmrc.helptosavefrontend.models.HtsAuth.AuthWithCL200
 import uk.gov.hmrc.helptosavefrontend.models.account.{Account, AccountNumber, BonusTerm}
@@ -114,7 +115,7 @@ class IntroductionControllerSpec
     "getHelpPage" should {
 
       "show the help page content if the user is logged in and has a HTS account" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino))
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino) and enrolmentsWithMatchingNino)
         mockEnrolmentCheck()(Right(Enrolled(true)))
         mockGetAccount(nino)(Right(account))
         mockGetAccountNumberFromService()(Right(AccountNumber(Some(accountNumber))))
@@ -127,7 +128,7 @@ class IntroductionControllerSpec
       }
 
       "show an error page if the user's enrolment status cannot be checked" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino))
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino) and enrolmentsWithMatchingNino)
         mockEnrolmentCheck()(Left(""))
 
         val result = helpToSave.getHelpPage(FakeRequest())
@@ -135,7 +136,7 @@ class IntroductionControllerSpec
       }
 
       "show the no-account page if the user does not have a HTS account" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino))
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino) and enrolmentsWithMatchingNino)
         mockEnrolmentCheck()(Right(NotEnrolled))
 
         val result = helpToSave.getHelpPage(FakeRequest())

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/RegisterControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/RegisterControllerSpec.scala
@@ -102,7 +102,7 @@ class RegisterControllerSpec
 
   def checkRedirectIfNoEmailInSession(doRequest: => Future[PlayResult]): Unit =
     "redirect to the give email page if the session data does not contain an email for the user" in {
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
       mockSessionStoreGet(Right(Some(HTSSession(Some(Right(randomEligibleWithUserInfo(validUserInfo))), None, None))))
 
@@ -204,7 +204,7 @@ class RegisterControllerSpec
       checkRedirectIfNoEmailInSession(doRequest())
 
       "show the user the create account page if the session data contains a confirmed email" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(
@@ -233,7 +233,7 @@ class RegisterControllerSpec
       "show an error page if the eligibility reason cannot be parsed" in {
         val userInfo = eligibleSpecificReasonCodeWithUserInfo(validUserInfo, 999)
         val eligibilityCheckResult = randomEligibility().value.eligibilityCheckResult.copy(reasonCode = 999)
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(
@@ -264,7 +264,7 @@ class RegisterControllerSpec
       }
 
       "show the appropriate page content for when user is eligible with reason code 6: UCClaimantAndIncomeSufficient" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(
@@ -291,7 +291,7 @@ class RegisterControllerSpec
 
       "show the appropriate page content for when user is eligible with reason code 7: UCClaimantButNoWTC" in {
         val userInfo = eligibleSpecificReasonCodeWithUserInfo(validUserInfo, 7)
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(
@@ -318,7 +318,7 @@ class RegisterControllerSpec
 
       "show the appropriate page content for when user is eligible with reason code 8: UCClaimantAndWTC" in {
         val userInfo = eligibleSpecificReasonCodeWithUserInfo(validUserInfo, 8)
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(
@@ -344,7 +344,7 @@ class RegisterControllerSpec
       }
 
       "show user not eligible page if the user is not eligible" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(Some(HTSSession(Some(Left(randomIneligibility())), None, None, None, None, Some(bankDetails))))
@@ -358,7 +358,7 @@ class RegisterControllerSpec
       "handle the case when there are no bank details stored in the session" in {
         val eligibilityResult = Some(Right(eligibleSpecificReasonCodeWithUserInfo(validUserInfo, 6)))
         val email = "valid@email.com"
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(HTSSession(eligibilityResult, Some(email), None))))
         mockSessionStorePut(
@@ -385,7 +385,7 @@ class RegisterControllerSpec
       "retrieve the user info from session cache and indicate to the user that the creation was successful " +
         "and enrol the user if the creation was successful" in {
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None, None, None, Some(bankDetails))))
@@ -410,7 +410,7 @@ class RegisterControllerSpec
 
       "indicate to the user that account creation was successful " +
         "even if the user couldn't be enrolled into hts at this time" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None, None, None, Some(bankDetails))))
@@ -434,7 +434,7 @@ class RegisterControllerSpec
       }
 
       "not update user counts but enrol the user if the user already had an account" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None, None, None, Some(bankDetails))))
@@ -447,7 +447,7 @@ class RegisterControllerSpec
       }
 
       "redirect the user to nsi when they already have an account" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None, None, None, Some(bankDetails))))
@@ -461,7 +461,7 @@ class RegisterControllerSpec
       }
 
       "redirect the user to the confirm details page if the session indicates they have not done so already" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(Some(HTSSession(Some(Right(randomEligibleWithUserInfo(validUserInfo))), None, None)))
@@ -473,7 +473,7 @@ class RegisterControllerSpec
       }
 
       "redirect user to bank_details page if the session doesn't contain bank details" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None))))
 
@@ -484,7 +484,7 @@ class RegisterControllerSpec
 
       "redirect to the create account error page" when {
         "the help to save service returns with an error" in {
-          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
           mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
           mockSessionStoreGet(
             Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None, None, None, Some(bankDetails))))
@@ -497,7 +497,7 @@ class RegisterControllerSpec
         }
 
         "there is an error writing to session" in {
-          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
           mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
           mockSessionStoreGet(
             Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None, None, None, Some(bankDetails))))
@@ -523,7 +523,7 @@ class RegisterControllerSpec
 
       "redirect to the create account bank details error page" when {
         "the errorMessageId received in the response from nsi is ZYRC0703" in {
-          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
           mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
           mockSessionStoreGet(
             Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None, None, None, Some(bankDetails))))
@@ -536,7 +536,7 @@ class RegisterControllerSpec
         }
 
         "the errorMessageId received in the response from nsi is ZYRC0707" in {
-          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
           mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
           mockSessionStoreGet(
             Right(Some(HTSSession(Some(Right(userInfo)), Some(confirmedEmail), None, None, None, Some(bankDetails))))
@@ -558,7 +558,7 @@ class RegisterControllerSpec
       "show the page correctly if the person is enrolled to HTS and the session has an account number in it" in {
         val accountNumber = UUID.randomUUID().toString
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
         mockSessionStoreGet(
           Right(Some(HTSSession(None, Some("email@gmail.com"), None, accountNumber = Some(accountNumber))))
@@ -576,7 +576,7 @@ class RegisterControllerSpec
       "redirect to check eligibility" when {
 
         "there is no session data" in {
-          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
           mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
           mockSessionStoreGet(Right(None))
 
@@ -586,7 +586,7 @@ class RegisterControllerSpec
         }
 
         "there is no account number in session" in {
-          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
           mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
           mockSessionStoreGet(Right(Some(HTSSession(None, None, None, accountNumber = None))))
 
@@ -596,7 +596,7 @@ class RegisterControllerSpec
         }
 
         "the person is not enrolled to HTS" in {
-          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
           mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
 
           val result = getAccountCreatedPage()
@@ -607,7 +607,7 @@ class RegisterControllerSpec
         "there is no email in the session" in {
           val accountNumber = UUID.randomUUID().toString
 
-          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
           mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
           mockSessionStoreGet(Right(Some(HTSSession(None, None, None, accountNumber = Some(accountNumber)))))
 
@@ -621,7 +621,7 @@ class RegisterControllerSpec
       "show an error page" when {
 
         "the enrolment status cannot be retrieved" in {
-          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
           mockEnrolmentCheck()(Left(""))
 
           val result = getAccountCreatedPage()
@@ -630,7 +630,7 @@ class RegisterControllerSpec
 
         "the session data could not be retrieved" in {
 
-          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+          mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
           mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
           mockSessionStoreGet(Left(""))
 
@@ -649,7 +649,7 @@ class RegisterControllerSpec
       "show errors on the page" in {
         val accountNumber = UUID.randomUUID().toString
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
         mockSessionStoreGet(
           Right(Some(HTSSession(None, Some("email@gmail.com"), None, accountNumber = Some(accountNumber))))
@@ -664,7 +664,7 @@ class RegisterControllerSpec
       "redirect to PayIn" in {
         val accountNumber = UUID.randomUUID().toString
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
         mockSessionStoreGet(
           Right(Some(HTSSession(None, Some("email@gmail.com"), None, accountNumber = Some(accountNumber))))
@@ -679,7 +679,7 @@ class RegisterControllerSpec
       "redirect to AccessAccount" in {
         val accountNumber = UUID.randomUUID().toString
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
         mockSessionStoreGet(
           Right(Some(HTSSession(None, Some("email@gmail.com"), None, accountNumber = Some(accountNumber))))
@@ -701,7 +701,7 @@ class RegisterControllerSpec
       behave like commonEnrolmentAndSessionBehaviour(() => doRequest())
 
       "show the error page" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(Some(HTSSession(Some(Right(randomEligibleWithUserInfo(validUserInfo))), Some(confirmedEmail), None)))
@@ -720,7 +720,7 @@ class RegisterControllerSpec
       behave like commonEnrolmentAndSessionBehaviour(() => doRequest())
 
       "show the error page" in {
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(
           Right(Some(HTSSession(Some(Right(randomEligibleWithUserInfo(validUserInfo))), Some(confirmedEmail), None)))
@@ -745,7 +745,7 @@ class RegisterControllerSpec
         val eligibilityResult = Some(Right(randomEligibleWithUserInfo(validUserInfo)))
         val session = HTSSession(eligibilityResult, Some("valid@email.com"), None, None, None, Some(bankDetails))
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(session)))
         mockSessionStorePut(
@@ -768,7 +768,7 @@ class RegisterControllerSpec
       "show user not eligible page if the user is not eligible" in {
         val session = HTSSession(Some(Left(randomIneligibility())), None, None, None, None, Some(bankDetails))
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(session)))
         val result = doRequest()
@@ -781,7 +781,7 @@ class RegisterControllerSpec
         val eligibilityResult = Some(Right(randomEligibleWithUserInfo(validUserInfo)))
         val session = HTSSession(eligibilityResult, Some("valid@email.com"), None)
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(session)))
         mockSessionStorePut(session)(Right(()))
@@ -801,7 +801,7 @@ class RegisterControllerSpec
         val eligibilityResult = Some(Right(randomEligibleWithUserInfo(validUserInfo)))
         val session = HTSSession(eligibilityResult, Some("valid@email.com"), None)
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(session)))
         mockSessionStorePut(session.copy(changingDetails = true))(Right(()))
@@ -822,7 +822,7 @@ class RegisterControllerSpec
         val eligibilityResult = Some(Right(randomEligibleWithUserInfo(validUserInfo)))
         val session = HTSSession(eligibilityResult, Some("valid@email.com"), None)
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(session)))
         mockSessionStorePut(session.copy(changingDetails = true))(Right(()))
@@ -842,7 +842,7 @@ class RegisterControllerSpec
         val eligibilityResult = Some(Right(randomEligibleWithUserInfo(validUserInfo)))
         val session = HTSSession(eligibilityResult, Some("valid@email.com"), None)
 
-        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+        mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
         mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
         mockSessionStoreGet(Right(Some(session)))
         mockSessionStorePut(session.copy(changingDetails = true))(Right(()))

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/ReminderControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/ReminderControllerSpec.scala
@@ -23,6 +23,7 @@ import play.api.http.Status
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.syntax.retrieved.authSyntaxForRetrieved
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.helptosavefrontend.audit.HTSAuditor
 import uk.gov.hmrc.helptosavefrontend.forms.ReminderFrequencyValidation
@@ -226,7 +227,7 @@ class ReminderControllerSpec
 
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockGetHtsUser(nino)(Right(getHtsUser))
 
       val result = csrfAddToken(controller.getEmailsavingsReminders())(fakeRequestWithNoBody)
@@ -237,7 +238,7 @@ class ReminderControllerSpec
 
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockGetHtsUser(nino)(Left("error occurred while getting htsUser"))
 
       val result = csrfAddToken(controller.getEmailsavingsReminders())(fakeRequestWithNoBody)
@@ -248,7 +249,7 @@ class ReminderControllerSpec
     "should return the reminder setting page when asked for it" in {
       val account = Account(false, 123.45, 0, 0, 0, LocalDate.parse("1900-01-01"), List(), None, None)
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino))
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino) and enrolmentsWithMatchingNino)
       mockGetAccount(nino)(Right(account))
 
       val result = csrfAddToken(controller.getSelectRendersPage())(FakeRequest())
@@ -258,7 +259,7 @@ class ReminderControllerSpec
     "should return acount closed page when account is closed" in {
       val account = Account(true, 123.45, 0, 0, 0, LocalDate.parse("1900-01-01"), List(), None, None)
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino))
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino) and enrolmentsWithMatchingNino)
       mockGetAccount(nino)(Right(account))
 
       val result = csrfAddToken(controller.getSelectRendersPage())(FakeRequest())
@@ -267,7 +268,7 @@ class ReminderControllerSpec
 
     "should return the reminder setting page when asked for " in {
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino))
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino) and enrolmentsWithMatchingNino)
       mockGetAccount(nino)(Left("error occurred while getting htsUser"))
 
       val result = csrfAddToken(controller.getSelectRendersPage())(FakeRequest())
@@ -287,7 +288,7 @@ class ReminderControllerSpec
 
     "should redirect to a renders confirmation set page with email encrypted " in {
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockDecrypt("encrypted")("email")
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
       val result = controller.getRendersConfirmPage("encrypted", "1st", "Set")(fakeRequestWithNoBody)
@@ -297,7 +298,7 @@ class ReminderControllerSpec
 
     "should redirect to a renders confirmation update page with email encrypted " in {
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockDecrypt("encrypted")("email")
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
       val result = controller.getRendersConfirmPage("encrypted", "1st", "Update")(fakeRequestWithNoBody)
@@ -309,7 +310,7 @@ class ReminderControllerSpec
       val account = Account(false, 123.45, 0, 0, 0, LocalDate.parse("1900-01-01"), List(), None, None)
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino))
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino) and enrolmentsWithMatchingNino)
       mockGetAccount(nino)(Right(account))
       val result = csrfAddToken(controller.getSelectedRendersPage())(fakeRequestWithNoBody)
       status(result) shouldBe Status.SEE_OTHER
@@ -320,7 +321,7 @@ class ReminderControllerSpec
       val account = Account(true, 123.45, 0, 0, 0, LocalDate.parse("1900-01-01"), List(), None, None)
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino))
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(Some(nino) and enrolmentsWithMatchingNino)
       mockGetAccount(nino)(Right(account))
       val result = csrfAddToken(controller.getSelectedRendersPage())(fakeRequestWithNoBody)
       status(result) shouldBe Status.OK
@@ -330,7 +331,7 @@ class ReminderControllerSpec
     "should return the internal error when selected reminderpage " in {
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockGetAccount(nino)(Left("error occurred while getting htsUser"))
 
       val result = csrfAddToken(controller.getSelectedRendersPage())(fakeRequestWithNoBody)
@@ -343,7 +344,7 @@ class ReminderControllerSpec
 
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockGetHtsUser(nino)(Right(getHtsUser))
 
       val result = csrfAddToken(controller.accountOpenGetSelectedRendersPage())(fakeRequestWithNoBody)
@@ -352,7 +353,7 @@ class ReminderControllerSpec
 
     "should return the internal error when error retrieving account " in {
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockGetHtsUser(nino)(Left("error occurred while getting htsUser"))
       val result = csrfAddToken(controller.accountOpenGetSelectedRendersPage())(fakeRequestWithNoBody)
       status(result) shouldBe Status.INTERNAL_SERVER_ERROR
@@ -362,7 +363,7 @@ class ReminderControllerSpec
 
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
 
       val result = csrfAddToken(controller.getRendersCancelConfirmPage())(fakeRequestWithNoBody)
       status(result) shouldBe Status.OK
@@ -475,7 +476,7 @@ class ReminderControllerSpec
 
       val fakeRequestWithNoBody = FakeRequest("POST", "/").withFormUrlEncodedBody("reminderFrequency" -> "")
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(Enrolled(true)))
 
       val result = csrfAddToken(controller.submitApplySavingsReminderPage())(fakeRequestWithNoBody)
@@ -485,7 +486,7 @@ class ReminderControllerSpec
     "should return the apply savings reminder  page when asked for it" in {
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
       mockSessionStoreGet(
         Right(
@@ -515,7 +516,7 @@ class ReminderControllerSpec
     "should return the apply savings reminder  page with out select when asked for it" in {
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(EnrolmentStatus.Enrolled(true)))
 
       val result = csrfAddToken(controller.getApplySavingsReminderPage())(fakeRequestWithNoBody)
@@ -525,7 +526,7 @@ class ReminderControllerSpec
     "should show a success page if the user submits an ApplySavingsReminderPage with No  " in {
       val fakeRequestWithNoBody = FakeRequest("POST", "/").withFormUrlEncodedBody("reminderFrequency" -> "no")
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(NotEnrolled))
       mockSessionStoreGet(Right(None))
 
@@ -536,7 +537,7 @@ class ReminderControllerSpec
     "should show a success page if the user submits an ApplySavingsReminderPage with no  " in {
       val fakeRequestWithNoBody = FakeRequest("POST", "/").withFormUrlEncodedBody("reminderFrequency" -> "no")
       val eligibilityResult = Some(Right(randomEligibleWithUserInfo(validUserInfo)))
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(NotEnrolled))
       mockSessionStoreGet(
         Right(
@@ -581,7 +582,7 @@ class ReminderControllerSpec
     "should show a success page if the user submits an ApplySavingsReminderPage with out option  " in {
       val fakeRequestWithNoBody = FakeRequest("POST", "/").withFormUrlEncodedBody("reminderFrequency" -> "yes")
       val eligibilityResult = Some(Right(randomEligibleWithUserInfo(validUserInfo)))
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(NotEnrolled))
       mockSessionStoreGet(
         Right(
@@ -621,7 +622,7 @@ class ReminderControllerSpec
     "should show a success page if the user submits an ApplySavingsReminderPage with yes  " in {
       val fakeRequestWithNoBody = FakeRequest("POST", "/").withFormUrlEncodedBody("reminderFrequency" -> "")
       val eligibilityResult = Some(Right(randomEligibleWithUserInfo(validUserInfo)))
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(NotEnrolled))
       mockSessionStoreGet(
         Right(
@@ -651,7 +652,7 @@ class ReminderControllerSpec
     "should return the apply savings reminder  signup page when asked for it" in {
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
 
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(Enrolled(true)))
 
       val result = csrfAddToken(controller.getApplySavingsReminderSignUpPage())(fakeRequestWithNoBody)
@@ -820,7 +821,7 @@ class ReminderControllerSpec
 
     "display the page with correct Back link when they came from SelectEmail page" in {
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
       mockSessionStoreGet(
         Right(Some(HTSSession(Some(Right(randomEligibleWithUserInfo(validUserInfo))), None, None)))
@@ -836,7 +837,7 @@ class ReminderControllerSpec
 
     "display the page with correct Back link when they came from emailVerified page" in {
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
       mockSessionStoreGet(
         Right(
@@ -869,7 +870,7 @@ class ReminderControllerSpec
 
     "display the page with correct Back link when they came from check details page" in {
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
       mockSessionStoreGet(
         Right(
@@ -899,7 +900,7 @@ class ReminderControllerSpec
     }
     "redirect user to eligibility checks if there is no session found" in {
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
       mockSessionStoreGet(Right(None))
 
@@ -910,7 +911,7 @@ class ReminderControllerSpec
 
     "redirect user to eligibility checks if there is a session but no eligibility result found in the session" in {
       val fakeRequestWithNoBody = FakeRequest("GET", "/")
-      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+      mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
       mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
       mockSessionStoreGet(Right(Some(HTSSession(None, None, None))))
 
@@ -973,7 +974,7 @@ class ReminderControllerSpec
 
   "show user an in-eligible page if the session is found but user is not eligible" in {
     val fakeRequestWithNoBody = FakeRequest("GET", "/")
-    mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+    mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
     mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
     mockSessionStoreGet(Right(Some(HTSSession(Some(Left(randomIneligibility())), None, None))))
 
@@ -984,7 +985,7 @@ class ReminderControllerSpec
   "show user an error page if the session is found but user is not eligible and in-eligibility reason can't be parsed" in {
     val fakeRequestWithNoBody = FakeRequest("GET", "/")
     val eligibilityCheckResult = randomIneligibility().value.eligibilityCheckResult.copy(reasonCode = 999)
-    mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrieval)
+    mockAuthWithNINORetrievalWithSuccess(AuthWithCL200)(mockedNINORetrievalWithPTEnrolment)
     mockEnrolmentCheck()(Right(EnrolmentStatus.NotEnrolled))
     mockSessionStoreGet(
       Right(


### PR DESCRIPTION
PR to address a security incident that has compromised some accounts. To address that, as part of HTS authentication
- Validate that the user session nino has a corresponding personal tax enrolment
- Validate that the user session nino matches to the nino from the personal tax enrolment

If any of the above validation steps fail, redirect the user to the personal tax endpoint. 