### PR TITLE
DLS-12407 | Update to remove legacy error handler

### DIFF
--- a/app/uk/gov/hmrc/helptosavefrontend/auth/HelpToSaveAuth.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/auth/HelpToSaveAuth.scala
@@ -57,7 +57,7 @@ trait HelpToSaveAuth extends AuthorisedFunctions with Logging {
       case (mayBeNino ~ enrolments, request, time) =>
         withNINO(mayBeNino, enrolments, time) { nino =>
           action(request)(HtsContextWithNINO(authorised = true, nino))
-        }(request)
+        }(request, ec)
     }(loginContinueURL)
 
   def authorisedForHtsWithNINOAndName(
@@ -70,7 +70,7 @@ trait HelpToSaveAuth extends AuthorisedFunctions with Logging {
         withNINO(mayBeNino, enrolments, time) { nino =>
           val name = maybeItmpName.flatMap(_.givenName)
           action(request)(HtsContextWithNINOAndFirstName(authorised = true, nino, name))
-        }(request)
+        }(request, ec)
     }(loginContinueURL)
 
   def authorisedForHtsWithInfo(
@@ -97,7 +97,7 @@ trait HelpToSaveAuth extends AuthorisedFunctions with Logging {
           )
 
           action(request)(HtsContextWithNINOAndUserDetails(authorised = true, nino, userDetails))
-        }(request)
+        }(request, ec)
     }(loginContinueURL)
 
   def authorisedForHts(
@@ -140,7 +140,7 @@ trait HelpToSaveAuth extends AuthorisedFunctions with Logging {
               }
           }
         }
-        .recover {
+        .recoverWith {
           val time = timer.stop()
           handleAuthFailure(loginContinueURL, time)
         }
@@ -148,10 +148,10 @@ trait HelpToSaveAuth extends AuthorisedFunctions with Logging {
 
   private def withNINO[A](mayBeNino: Option[String], enrolments: Enrolments, nanos: Long)(
     action: NINO => Future[Result]
-  )(implicit request: Request[_]): Future[Result] =
+  )(implicit request: Request[_], ec: ExecutionContext): Future[Result] =
     mayBeNino.fold {
       logger.warn(s"NINO retrieval failed ${timeString(nanos)}")
-      toFuture(internalServerError())
+      internalServerError()
     } { nino =>
       enrolments.getEnrolment("HMRC-PT").flatMap(_.getIdentifier("NINO")) match {
         case enrolmentIdentifiers
@@ -230,19 +230,20 @@ trait HelpToSaveAuth extends AuthorisedFunctions with Logging {
       extends AuthorisationException("MaintenancePeriodException")
 
   def handleAuthFailure(loginContinueURL: RelativeURL, time: Long)(
-    implicit request: Request[_]
-  ): PartialFunction[Throwable, Result] = {
+    implicit request: Request[_],
+    ec: ExecutionContext
+  ): PartialFunction[Throwable, Future[Result]] = {
     case _: NoActiveSession =>
-      toGGLogin(loginContinueURL)
+      toFuture(toGGLogin(loginContinueURL))
 
     case _: InsufficientConfidenceLevel | _: InsufficientEnrolments =>
-      SeeOther(appConfig.ivUrl(loginContinueURL))
+      toFuture(SeeOther(appConfig.ivUrl(loginContinueURL)))
 
     case MaintenancePeriodException(endTime: LocalDateTime) =>
-      SeeOther(routes.RegisterController.getServiceOutagePage(endTime.toString).url)
+      toFuture(SeeOther(routes.RegisterController.getServiceOutagePage(endTime.toString).url))
 
     case _: UnsupportedAuthProvider =>
-      SeeOther(routes.RegisterController.getCannotCheckDetailsPage.url)
+      toFuture(SeeOther(routes.RegisterController.getCannotCheckDetailsPage.url))
 
     case ex: AuthorisationException =>
       logger.warn(s"could not authenticate user due to: $ex ${timeString(time)}")
@@ -261,6 +262,6 @@ trait HelpToSaveAuth extends AuthorisedFunctions with Logging {
 
   private def timeString(nanos: Long): String = s"(round-trip time: ${nanosToPrettyString(nanos)})"
 
-  def internalServerError()(implicit request: Request[_]): Result
+  def internalServerError()(implicit request: Request[_], ec: ExecutionContext): Future[Result]
 
 }

--- a/app/uk/gov/hmrc/helptosavefrontend/config/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/config/ErrorHandler.scala
@@ -17,25 +17,27 @@
 package uk.gov.hmrc.helptosavefrontend.config
 
 import play.api.i18n.MessagesApi
-import play.api.mvc.Request
+import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import uk.gov.hmrc.helptosavefrontend.models.HtsContext
 import uk.gov.hmrc.helptosavefrontend.views.html.core.error_template
-import uk.gov.hmrc.play.bootstrap.frontend.http.LegacyFrontendErrorHandler
+import uk.gov.hmrc.play.bootstrap.frontend.http.FrontendErrorHandler
 
 import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ErrorHandler @Inject() (
   implicit val messagesApi: MessagesApi,
   val appConfig: FrontendAppConfig,
-  errorTemplateView: error_template
-) extends LegacyFrontendErrorHandler {
+  errorTemplateView: error_template,
+  protected val ec: ExecutionContext
+) extends FrontendErrorHandler {
 
   override def standardErrorTemplate(pageTitle: String, heading: String, message: String)(
-    implicit request: Request[_]
-  ): Html = {
+    implicit requestHeader: RequestHeader
+  ): Future[Html] = {
     implicit val htsContext: HtsContext = HtsContext(false)
-    errorTemplateView(pageTitle, heading, message)
+    Future.successful(errorTemplateView(pageTitle, heading, message))
   }
 }

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/AccessAccountController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/AccessAccountController.scala
@@ -118,28 +118,23 @@ class AccessAccountController @Inject() (
 
   def getNoAccountPage: Action[AnyContent] =
     authorisedForHtsWithNINO { implicit request => implicit htsContext =>
-      sessionStore.get.value.flatMap(
-        _.fold(
-          { e =>
-            logger.warn(s"Could not get session data: $e")
-            internalServerError()
-          }, { session =>
-            checkIfEnrolled(
-              { () =>
-                Ok(confirmCheckEligibility())
-              }, { _ =>
-                SeeOther(routes.EligibilityCheckController.getCheckEligibility.url)
-              },
-              () =>
-                SeeOther(
-                  session
-                    .flatMap(_.attemptedAccountHolderPageURL)
-                    .getOrElse(appConfig.nsiManageAccountUrl)
-                )
+      foldWithInternalServerError(sessionStore.get)(
+        e => logger.warn(s"Could not get session data: $e")
+      ) { session =>
+        checkIfEnrolled(
+          { () =>
+            Ok(confirmCheckEligibility())
+          }, { _ =>
+            SeeOther(routes.EligibilityCheckController.getCheckEligibility.url)
+          },
+          () =>
+            SeeOther(
+              session
+                .flatMap(_.attemptedAccountHolderPageURL)
+                .getOrElse(appConfig.nsiManageAccountUrl)
             )
-          }
         )
-      )
+      }
 
     }(loginContinueURL = routes.AccessAccountController.getNoAccountPage.url)
 
@@ -151,15 +146,11 @@ class AccessAccountController @Inject() (
   ): Future[Result] = {
 
     def storeAttemptedRedirectThenRedirect(redirectTo: String): Future[Result] =
-      sessionStore
-        .store(HTSSession.empty.copy(attemptedAccountHolderPageURL = Some(pageURL)))
-        .value
-        .map {
-          _.fold[Result]({ e =>
-            logger.warn(s"Could not store session data: $e")
-            internalServerError()
-          }, _ => SeeOther(redirectTo))
-        }
+      foldWithInternalServerError(
+        sessionStore.store(HTSSession.empty.copy(attemptedAccountHolderPageURL = Some(pageURL)))
+      )(
+        e => logger.warn(s"Could not store session data: $e")
+      )(_ => toFuture(SeeOther(redirectTo)))
 
     checkIfEnrolled(
       {

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/AccountHolderController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/AccountHolderController.scala
@@ -147,20 +147,19 @@ class AccountHolderController @Inject() (
   def emailVerifiedCallback(emailVerificationParams: String): Action[AnyContent] = {
     val path = routes.AccountHolderController.emailVerifiedCallback(emailVerificationParams).url
     authorisedForHtsWithInfo { implicit request => implicit htsContext =>
-      withEmailVerificationParameters(
-        emailVerificationParams,
-        params =>
-          EitherT.right(
-            checkIfAlreadyEnrolled(
-              oldEmail => handleEmailVerified(params, oldEmail, path),
-              routes.AccountHolderController.getUpdateYourEmailAddress.url
-            )
-          ),
-        EitherT.right(toFuture(SeeOther(routes.EmailController.confirmEmailErrorTryLater.url)))
-      )(path).leftMap { e =>
-        logger.warn(e)
-        internalServerError()
-      }.merge
+      mergeWithInternalServerError(
+        withEmailVerificationParameters(
+          emailVerificationParams,
+          params =>
+            EitherT.right(
+              checkIfAlreadyEnrolled(
+                oldEmail => handleEmailVerified(params, oldEmail, path),
+                routes.AccountHolderController.getUpdateYourEmailAddress.url
+              )
+            ),
+          EitherT.right(toFuture(SeeOther(routes.EmailController.confirmEmailErrorTryLater.url)))
+        )(path)
+      )(e => logger.warn(e))
     }(loginContinueURL = path)
   }
 

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/BankAccountController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/BankAccountController.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.helptosavefrontend.controllers
 
-import cats.instances.future._
 import com.google.inject.{Inject, Singleton}
 import play.api.mvc.{Result => PlayResult, _}
 import play.api.{Configuration, Environment}
@@ -93,38 +92,44 @@ class BankAccountController @Inject() (
                 .validateBankDetails(
                   ValidateBankDetailsRequest(htsContext.nino, bankDetails.sortCode.toString, bankDetails.accountNumber)
                 )
-                .fold[Future[PlayResult]](
-                  error => {
-                    logger.warn(s"Could not validate bank details due to : $error")
-                    internalServerError()
-                  }, { result =>
-                    if (result.isValid && result.sortCodeExists) {
-                      sessionStore
-                        .store(session.copy(bankDetails = Some(bankDetails)))
-                        .fold(
-                          error => {
-                            logger.warn(s"Could not update session with bank details: $error")
-                            internalServerError()
-                          },
-                          _ => SeeOther(routes.RegisterController.getCreateAccountPage.url)
-                        )
-                    } else {
-                      val formWithErrors = if (result.isValid && !result.sortCodeExists) {
-                        BankDetailsForm
-                          .giveBankDetailsForm()
-                          .fill(bankDetails)
-                          .withError("sortCode", BankDetailsValidation.ErrorMessages.sortCodeBackendInvalid)
+                .value
+                .flatMap(
+                  _.fold[Future[PlayResult]](
+                    error => {
+                      logger.warn(s"Could not validate bank details due to : $error")
+                      internalServerError()
+                    }, { result =>
+                      if (result.isValid && result.sortCodeExists) {
+                        sessionStore
+                          .store(session.copy(bankDetails = Some(bankDetails)))
+                          .value
+                          .flatMap(
+                            _.fold[Future[PlayResult]](
+                              error => {
+                                logger.warn(s"Could not update session with bank details: $error")
+                                internalServerError()
+                              },
+                              _ => toFuture(SeeOther(routes.RegisterController.getCreateAccountPage.url))
+                            )
+                          )
                       } else {
-                        BankDetailsForm
-                          .giveBankDetailsForm()
-                          .fill(bankDetails)
-                          .withError("sortCode", BankDetailsValidation.ErrorMessages.sortCodeBackendInvalid)
-                          .withError("accountNumber", BankDetailsValidation.ErrorMessages.accountNumberBackendInvalid)
-                      }
+                        val formWithErrors = if (result.isValid && !result.sortCodeExists) {
+                          BankDetailsForm
+                            .giveBankDetailsForm()
+                            .fill(bankDetails)
+                            .withError("sortCode", BankDetailsValidation.ErrorMessages.sortCodeBackendInvalid)
+                        } else {
+                          BankDetailsForm
+                            .giveBankDetailsForm()
+                            .fill(bankDetails)
+                            .withError("sortCode", BankDetailsValidation.ErrorMessages.sortCodeBackendInvalid)
+                            .withError("accountNumber", BankDetailsValidation.ErrorMessages.accountNumberBackendInvalid)
+                        }
 
-                      Ok(bankAccountDetails(formWithErrors, backLinkFromSession(session)))
+                        Ok(bankAccountDetails(formWithErrors, backLinkFromSession(session)))
+                      }
                     }
-                  }
+                  )
                 )
                 .flatMap(identity _)
             }

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/CustomBaseController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/CustomBaseController.scala
@@ -16,14 +16,19 @@
 
 package uk.gov.hmrc.helptosavefrontend.controllers
 
+import cats.data.EitherT
+import cats.instances.future._
 import com.google.inject.{Inject, Singleton}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{MessagesControllerComponents, Request, RequestHeader, Result}
 import uk.gov.hmrc.helptosavefrontend.config.{ErrorHandler, FrontendAppConfig}
 import uk.gov.hmrc.helptosavefrontend.util.MaintenanceSchedule
+import uk.gov.hmrc.helptosavefrontend.util.{Result => EitherTResult}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
+
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class CustomBaseController @Inject() (
@@ -44,8 +49,33 @@ class CustomBaseController @Inject() (
   implicit override def hc(implicit rh: RequestHeader): HeaderCarrier =
     HeaderCarrierConverter.fromRequestAndSession(rh, rh.session)
 
-  def internalServerError()(implicit request: Request[_]): Result =
-    InternalServerError(errorHandler.internalServerErrorTemplate(request))
+  def internalServerError()(implicit request: Request[_], ec: ExecutionContext): Future[Result] =
+    errorHandler.internalServerErrorTemplate(request).map(InternalServerError(_))
+
+  protected def internalServerErrorResultT(implicit request: Request[_], ec: ExecutionContext): EitherTResult[Result] =
+    EitherT.liftF(internalServerError())
+
+  protected def foldWithInternalServerError[A](
+    result: EitherTResult[A]
+  )(
+    onError: String => Unit
+  )(
+    onSuccess: A => Future[Result]
+  )(implicit request: Request[_], ec: ExecutionContext): Future[Result] =
+    result.foldF(
+      e => {
+        onError(e)
+        internalServerError()
+      },
+      onSuccess
+    )
+
+  protected def mergeWithInternalServerError(
+    result: EitherTResult[Result]
+  )(
+    onError: String => Unit
+  )(implicit request: Request[_], ec: ExecutionContext): Future[Result] =
+    foldWithInternalServerError(result)(onError)(Future.successful)
 }
 
 class CommonPlayDependencies @Inject() (val appConfig: FrontendAppConfig, val messagesApi: MessagesApi)

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/EligibilityCheckController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/EligibilityCheckController.scala
@@ -118,12 +118,7 @@ class EligibilityCheckController @Inject() (
                             )
       } yield eligibilityResult
 
-      result
-        .leftMap[PlayResult]({ e =>
-          logger.warn(s"Could not check eligibility: $e")
-          internalServerError()
-        })
-        .merge
+      mergeWithInternalServerError(result)(e => logger.warn(s"Could not check eligibility: $e"))
     }(loginContinueURL = routes.EligibilityCheckController.getCheckEligibility.url)
 
   def getIsNotEligible: Action[AnyContent] =
@@ -219,13 +214,9 @@ class EligibilityCheckController @Inject() (
         logger.warn(s"User has missing information: ${missingUserInfo.missingInfo.mkString(",")}", missingUserInfo.nino)
         SeeOther(routes.EligibilityCheckController.getMissingInfoPage.url)
       }, { userInfo =>
-        performEligibilityChecks(userInfo).fold(
-          { e =>
-            logger.warn(e, htsContext.nino)
-            internalServerError()
-          },
-          handleEligibilityResult(_, session)
-        )
+        foldWithInternalServerError(performEligibilityChecks(userInfo))(
+          e => logger.warn(e, htsContext.nino)
+        )(handleEligibilityResult(_, session))
       }
     )
 

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/EmailController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/EmailController.scala
@@ -293,13 +293,9 @@ class EmailController @Inject() (
           r <- EitherT.liftF(ifSuccess)
         } yield r
 
-        result.fold(
-          { e =>
-            logger.warn(s"Could not write confirmed email: $e", nino)
-            internalServerError()
-          },
-          identity
-        )
+        foldWithInternalServerError(result)(
+          e => logger.warn(s"Could not write confirmed email: $e", nino)
+        )(toFuture)
       }
 
       def ifDigitalNewApplicant(session: Option[HTSSession]) =
@@ -351,13 +347,9 @@ class EmailController @Inject() (
                   }
                 } yield r
 
-                result.fold[Result](
-                  errors => {
-                    logger.warn(s"error during update email, error = $errors")
-                    internalServerError()
-                  },
-                  identity
-                )
+                foldWithInternalServerError(result)(
+                  errors => logger.warn(s"error during update email, error = $errors")
+                )(toFuture)
               }
             )
           }
@@ -380,10 +372,7 @@ class EmailController @Inject() (
               )
         } yield r
 
-      result.leftMap { e =>
-        logger.warn(e)
-        internalServerError()
-      }.merge
+      mergeWithInternalServerError(result)(e => logger.warn(e))
     }(loginContinueURL = routes.EmailController.emailConfirmedCallback(emailVerificationParams).url)
 
   private def handleCallback(status: EnrolmentStatus, emailVerificationParams: String, path: String)(
@@ -443,7 +432,7 @@ class EmailController @Inject() (
     htsContext.userDetails.fold[EitherT[Future, String, Result]](
       missingInfo => {
         logger.warn(s"DE user missing infos, missing = ${missingInfo.missingInfo.mkString(",")}")
-        EitherT.pure[Future, String](internalServerError())
+        internalServerErrorResultT
       },
       userInfo => {
         withEmailVerificationParameters(
@@ -496,15 +485,9 @@ class EmailController @Inject() (
     if (original.contains(updated)) {
       ifSuccessful
     } else {
-      sessionStore
-        .store(updated)
-        .fold[Result](
-          e => {
-            logger.warn(s"error updating the session, error = $e")
-            internalServerError()
-          },
-          _ => ifSuccessful
-        )
+      foldWithInternalServerError(sessionStore.store(updated))(
+        e => logger.warn(s"error updating the session, error = $e")
+      )(_ => toFuture(ifSuccessful))
     }
 
   /** Return `None` if user is ineligible */
@@ -848,33 +831,23 @@ class EmailController @Inject() (
       enrolmentStatus <- helpToSaveService.getUserEnrolmentStatus()
     } yield session -> enrolmentStatus
 
-    result
-      .leftSemiflatMap { e =>
-        logger.warn(s"Could not get session or enrolment status: $e")
-        internalServerError()
-      }
-      .semiflatMap {
+    mergeWithInternalServerError(
+      result.semiflatMap {
         case (session, enrolmentStatus) =>
           enrolmentStatus.fold(
             ifDuringRegistrationJourney(session), { _ =>
-              helpToSaveService
-                .getConfirmedEmail()
-                .leftSemiflatMap { e =>
-                  logger.warn(s"Could not get confirmed email: $e")
-                  internalServerError()
-                }
-                .semiflatMap {
+              mergeWithInternalServerError(
+                helpToSaveService.getConfirmedEmail().semiflatMap {
                   // Digital account holder
                   case Some(email) => ifDigitalAccountHolder(session, email)
                   // DE account holder
                   case None => ifDE(session)
                 }
-                .merge
-
+              )(e => logger.warn(s"Could not get confirmed email: $e"))
             }
           )
       }
-      .merge
+    )(e => logger.warn(s"Could not get session or enrolment status: $e"))
   }
 
   private def decryptEmail(encryptedEmail: String): Either[String, String] =

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/EnrollAndEligibilityCheck.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/EnrollAndEligibilityCheck.scala
@@ -47,7 +47,7 @@ trait EnrollAndEligibilityCheck extends SessionBehaviour with EnrolmentCheckBeha
 
               ineligibilityType.fold {
                 logger.warn(s"Could not parse ineligibility reason : $ineligibleReason")
-                toFuture(internalServerError())
+                internalServerError()
               } { _ =>
                 toFuture(SeeOther(routes.EligibilityCheckController.getIsNotEligible.url))
               }

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/IvController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/IvController.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.helptosavefrontend.controllers
 
-import cats.instances.future._
 import com.google.inject.{Inject, Singleton}
 import play.api.mvc._
 import play.api.{Configuration, Environment}
@@ -204,14 +203,17 @@ class IvController @Inject() (
   ): Future[Result] =
     sessionStore
       .store(session)
-      .fold(
-        { e =>
-          logger.warn(
-            s"Could not write to session cache after redirect from IV (journey ID: ${journeyId.getOrElse("not found")}): $e"
-          )
-          internalServerError()
-        },
-        _ => SeeOther(redirectTo)
+      .value
+      .flatMap(
+        _.fold[Future[Result]](
+          { e =>
+            logger.warn(
+              s"Could not write to session cache after redirect from IV (journey ID: ${journeyId.getOrElse("not found")}): $e"
+            )
+            internalServerError()
+          },
+          _ => toFuture(SeeOther(redirectTo))
+        )
       )
 
   private def retrieveURLFromSessionCache(url: HTSSession => Option[String], defaultUrl: String)(f: String => Result)(
@@ -219,23 +221,25 @@ class IvController @Inject() (
     request: Request[_],
     hc: HeaderCarrier
   ): Future[Result] =
-    sessionStore.get.fold(
-      { e =>
-        logger.warn(s"Could not retrieve data from session cache: $e")
-        internalServerError()
-      }, { mayBeSession =>
-        mayBeSession.fold {
-          logger.warn(s"no session found for user in mongo, redirecting to $defaultUrl")
-          f(defaultUrl)
-        } { session =>
-          url(session).fold {
-            logger.warn("session exists in mongo but required information is not found")
-            internalServerError()
-          }(
-            f
-          )
+    sessionStore.get.value.flatMap(
+      _.fold[Future[Result]](
+        { e =>
+          logger.warn(s"Could not retrieve data from session cache: $e")
+          internalServerError()
+        }, { mayBeSession =>
+          mayBeSession.fold[Future[Result]] {
+            logger.warn(s"no session found for user in mongo, redirecting to $defaultUrl")
+            toFuture(f(defaultUrl))
+          } { session =>
+            url(session).fold[Future[Result]] {
+              logger.warn("session exists in mongo but required information is not found")
+              internalServerError()
+            }(
+              u => toFuture(f(u))
+            )
+          }
         }
-      }
+      )
     )
 
 }

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/RegisterController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/RegisterController.scala
@@ -96,36 +96,33 @@ class RegisterController @Inject() (
                     sessionStore.get
                   })
       } yield session
-      result.fold(
-        { e =>
-          logger.warn(s"Could not get enrolment status or session: $e")
-          internalServerError()
-        }, { session =>
-          val accountNumberAndEmail: Option[(String, Email)] = for {
-            s <- session
-            a <- s.accountNumber
-            e <- s.confirmedEmail
-          } yield (a, e)
+      foldWithInternalServerError(result)(
+        e => logger.warn(s"Could not get enrolment status or session: $e")
+      ) { session =>
+        val accountNumberAndEmail: Option[(String, Email)] = for {
+          s <- session
+          a <- s.accountNumber
+          e <- s.confirmedEmail
+        } yield (a, e)
 
-          accountNumberAndEmail.fold(SeeOther(routes.EligibilityCheckController.getCheckEligibility.url)) {
-            case (accountNumber, email) =>
-              val lastDayOfMonth = LocalDate.now(clock).`with`(TemporalAdjusters.lastDayOfMonth())
-              this.payNowForm
-                .bindFromRequest()
-                .fold(
-                  e => {
-                    Ok(accountCreatedView(e, accountNumber, email, lastDayOfMonth))
-                  },
-                  payInNow =>
-                    if (payInNow) {
-                      SeeOther(routes.AccessAccountController.payIn.url)
-                    } else {
-                      SeeOther(routes.AccessAccountController.accessAccount.url)
-                    }
-                )
-          }
+        accountNumberAndEmail.fold(SeeOther(routes.EligibilityCheckController.getCheckEligibility.url)) {
+          case (accountNumber, email) =>
+            val lastDayOfMonth = LocalDate.now(clock).`with`(TemporalAdjusters.lastDayOfMonth())
+            this.payNowForm
+              .bindFromRequest()
+              .fold(
+                e => {
+                  Ok(accountCreatedView(e, accountNumber, email, lastDayOfMonth))
+                },
+                payInNow =>
+                  if (payInNow) {
+                    SeeOther(routes.AccessAccountController.payIn.url)
+                  } else {
+                    SeeOther(routes.AccessAccountController.accessAccount.url)
+                  }
+              )
         }
-      )
+      }
     }(loginContinueURL = routes.RegisterController.getCreateAccountPage.url)
 
   val payNowForm: Form[Boolean] = {
@@ -140,37 +137,35 @@ class RegisterController @Inject() (
     authorisedForHtsWithNINO { implicit request => implicit htsContext =>
       checkIfAlreadyEnrolled { () =>
         checkIfDoneEligibilityChecks { eligibleWithInfo =>
-          sessionStore
-            .store(eligibleWithInfo.session.copy(changingDetails = false))
-            .fold(
-              { _ =>
+          foldWithInternalServerError(sessionStore.store(eligibleWithInfo.session.copy(changingDetails = false)))(
+            _ => ()
+          ) { _ =>
+            EligibilityReason
+              .fromEligible(eligibleWithInfo.userInfo.eligible)
+              .fold[Future[Result]] {
+                logger.warn(
+                  s"Could not parse eligibility reason: ${eligibleWithInfo.userInfo.eligible}",
+                  eligibleWithInfo.userInfo.userInfo.nino
+                )
                 internalServerError()
-              }, { _ =>
-                EligibilityReason
-                  .fromEligible(eligibleWithInfo.userInfo.eligible)
-                  .fold {
-                    logger.warn(
-                      s"Could not parse eligibility reason: ${eligibleWithInfo.userInfo.eligible}",
-                      eligibleWithInfo.userInfo.userInfo.nino
-                    )
-                    internalServerError()
-                  } { _ =>
-                    val period = eligibleWithInfo.session.reminderDetails.getOrElse("noValue")
-                    eligibleWithInfo.session.bankDetails match {
-                      case Some(bankDetails) =>
-                        Ok(
-                          createAccountView(
-                            eligibleWithInfo.userInfo,
-                            period,
-                            eligibleWithInfo.email,
-                            bankDetails
-                          )
+              } { _ =>
+                val period = eligibleWithInfo.session.reminderDetails.getOrElse("noValue")
+                eligibleWithInfo.session.bankDetails match {
+                  case Some(bankDetails) =>
+                    toFuture(
+                      Ok(
+                        createAccountView(
+                          eligibleWithInfo.userInfo,
+                          period,
+                          eligibleWithInfo.email,
+                          bankDetails
                         )
-                      case None => SeeOther(routes.BankAccountController.getBankDetailsPage.url)
-                    }
-                  }
+                      )
+                    )
+                  case None => toFuture(SeeOther(routes.BankAccountController.getBankDetailsPage.url))
+                }
               }
-            )
+          }
         }
       }
     }(loginContinueURL = routes.RegisterController.getCreateAccountPage.url)
@@ -292,8 +287,8 @@ class RegisterController @Inject() (
         ),
         nino
       )
-      helpToSaveReminderService
-        .updateHtsUser(
+      val result =
+        helpToSaveReminderService.updateHtsUser(
           HtsUserSchedule(
             Nino(nino),
             eligibleWithInfo.email,
@@ -303,14 +298,11 @@ class RegisterController @Inject() (
             DateToDaysMapper.d2dMapper.getOrElse(daysToReceiveReminders, Seq())
           )
         )
-        .fold(
-          { _ =>
-            internalServerError()
-          }, { htsUser =>
-            logger.info(s"reminder updated ${htsUser.nino}")
-            SeeOther(routes.RegisterController.getAccountCreatedPage.url)
-          }
-        )
+
+      foldWithInternalServerError(result)(_ => ()) { htsUser =>
+        logger.info(s"reminder updated ${htsUser.nino}")
+        toFuture(SeeOther(routes.RegisterController.getAccountCreatedPage.url))
+      }
 
     } else {
       SeeOther(routes.RegisterController.getAccountCreatedPage.url)
@@ -326,24 +318,21 @@ class RegisterController @Inject() (
                   })
       } yield session
 
-      result.fold(
-        { e =>
-          logger.warn(s"Could not get enrolment status or session: $e")
-          internalServerError()
-        }, { session =>
-          val accountNumberAndEmail: Option[(String, Email)] = for {
-            s <- session
-            a <- s.accountNumber
-            e <- s.confirmedEmail
-          } yield (a, e)
+      foldWithInternalServerError(result)(
+        e => logger.warn(s"Could not get enrolment status or session: $e")
+      ) { session =>
+        val accountNumberAndEmail: Option[(String, Email)] = for {
+          s <- session
+          a <- s.accountNumber
+          e <- s.confirmedEmail
+        } yield (a, e)
 
-          accountNumberAndEmail.fold(SeeOther(routes.EligibilityCheckController.getCheckEligibility.url)) {
-            case (accountNumber, email) =>
-              val lastDayOfMonth = LocalDate.now(clock).`with`(TemporalAdjusters.lastDayOfMonth())
-              Ok(accountCreatedView(payNowForm, accountNumber, email, lastDayOfMonth))
-          }
+        accountNumberAndEmail.fold(SeeOther(routes.EligibilityCheckController.getCheckEligibility.url)) {
+          case (accountNumber, email) =>
+            val lastDayOfMonth = LocalDate.now(clock).`with`(TemporalAdjusters.lastDayOfMonth())
+            Ok(accountCreatedView(payNowForm, accountNumber, email, lastDayOfMonth))
         }
-      )
+      }
     }(loginContinueURL = routes.RegisterController.getCreateAccountPage.url)
 
   def getCreateAccountErrorPage: Action[AnyContent] =
@@ -408,9 +397,10 @@ class RegisterController @Inject() (
   )(implicit request: Request[_], hc: HeaderCarrier): Future[Result] =
     sessionStore
       .store(session.copy(changingDetails = true))
-      .fold({ _ =>
+      .value
+      .flatMap(_.fold[Future[Result]]({ _ =>
         internalServerError()
-      }, _ => SeeOther(redirectTo))
+      }, _ => toFuture(SeeOther(redirectTo))))
 
   /**
     * Checks the HTSSession data from mongo - if the is no session the user has not done the eligibility

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/ReminderController.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/ReminderController.scala
@@ -15,6 +15,7 @@
  */
 
 package uk.gov.hmrc.helptosavefrontend.controllers
+
 import cats.instances.future.*
 import cats.instances.string.*
 import cats.syntax.eq.*
@@ -32,13 +33,13 @@ import uk.gov.hmrc.helptosavefrontend.models.*
 import uk.gov.hmrc.helptosavefrontend.models.reminder.{CancelHtsUserReminder, DateToDaysMapper, DaysToDateMapper, HtsUserSchedule}
 import uk.gov.hmrc.helptosavefrontend.repo.SessionStore
 import uk.gov.hmrc.helptosavefrontend.services.{HelpToSaveReminderService, HelpToSaveService}
-import uk.gov.hmrc.helptosavefrontend.util.*
+import uk.gov.hmrc.helptosavefrontend.util.{Result => _, *}
 import uk.gov.hmrc.helptosavefrontend.views.html.closeaccount.account_closed
 import uk.gov.hmrc.helptosavefrontend.views.html.reminder.*
 
 import java.time.LocalDate
 import java.util.UUID
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 @Singleton
@@ -201,23 +202,28 @@ class ReminderController @Inject() (
                         )
                         helpToSaveReminderService
                           .updateHtsUser(htsUserToBeUpdated)
-                          .fold(
-                            htsError => {
-                              logger.warn(
-                                s"An error occurred while accessing HTS Reminder service for user: ${userInfo.nino} Error: $htsError"
-                              )
-                              internalServerError()
-                            },
-                            htsUser =>
-                              SeeOther(
-                                routes.ReminderController
-                                  .getRendersConfirmPage(
-                                    crypto.encrypt(htsUser.email),
-                                    success.reminderFrequency,
-                                    "Set"
+                          .value
+                          .flatMap(
+                            _.fold[Future[Result]](
+                              htsError => {
+                                logger.warn(
+                                  s"An error occurred while accessing HTS Reminder service for user: ${userInfo.nino} Error: $htsError"
+                                )
+                                internalServerError()
+                              },
+                              htsUser =>
+                                toFuture(
+                                  SeeOther(
+                                    routes.ReminderController
+                                      .getRendersConfirmPage(
+                                        crypto.encrypt(htsUser.email),
+                                        success.reminderFrequency,
+                                        "Set"
+                                      )
+                                      .url
                                   )
-                                  .url
-                              )
+                                )
+                            )
                           )
 
                       }
@@ -271,20 +277,23 @@ class ReminderController @Inject() (
     authorisedForHtsWithNINO { implicit request => implicit htsContext =>
       helpToSaveService
         .getAccount(htsContext.nino, UUID.randomUUID())
-        .fold(
-          e => {
-            logger.warn(s"error retrieving Account details from NS&I, error = $e")
-            internalServerError()
-          }, { account =>
-            {
-              if (account.isClosed) {
-                def bckLink: String = routes.ReminderController.getEmailsavingsReminders.url
-                Ok(accountClosed(Some(bckLink), account.closureDate.getOrElse(LocalDate.now())))
-              } else {
-                SeeOther(routes.ReminderController.accountOpenGetSelectedRendersPage.url)
+        .value
+        .flatMap(
+          _.fold[Future[Result]](
+            e => {
+              logger.warn(s"error retrieving Account details from NS&I, error = $e")
+              internalServerError()
+            }, { account =>
+              {
+                if (account.isClosed) {
+                  def bckLink: String = routes.ReminderController.getEmailsavingsReminders.url
+                  toFuture(Ok(accountClosed(Some(bckLink), account.closureDate.getOrElse(LocalDate.now()))))
+                } else {
+                  toFuture(SeeOther(routes.ReminderController.accountOpenGetSelectedRendersPage.url))
+                }
               }
             }
-          }
+          )
         )
     }(loginContinueURL = routes.ReminderController.selectRemindersSubmit.url)
 
@@ -294,21 +303,26 @@ class ReminderController @Inject() (
         def bckLink: String = routes.ReminderController.getEmailsavingsReminders.url
         helpToSaveReminderService
           .getHtsUser(htsContext.nino)
-          .fold(
-            _ => {
-              logger.warn(s"error retrieving Hts User details from reminder${htsContext.nino}")
-              internalServerError()
-            }, { htsUser =>
-              Ok(
-                reminderFrequencySet(
-                  ReminderForm.giveRemindersDetailsForm(),
-                  DaysToDateMapper.reverseMapper.getOrElse(htsUser.daysToReceive, "String"),
-                  "cancel",
-                  Some(bckLink)
+          .value
+          .flatMap(
+            _.fold[Future[Result]](
+              _ => {
+                logger.warn(s"error retrieving Hts User details from reminder${htsContext.nino}")
+                internalServerError()
+              }, { htsUser =>
+                toFuture(
+                  Ok(
+                    reminderFrequencySet(
+                      ReminderForm.giveRemindersDetailsForm(),
+                      DaysToDateMapper.reverseMapper.getOrElse(htsUser.daysToReceive, "String"),
+                      "cancel",
+                      Some(bckLink)
+                    )
+                  )
                 )
-              )
 
-            }
+              }
+            )
           )
       } else {
         SeeOther(routes.RegisterController.getServiceUnavailablePage.url)
@@ -348,14 +362,17 @@ class ReminderController @Inject() (
                           val cancelHtsUserReminder = CancelHtsUserReminder(htsContext.nino)
                           helpToSaveReminderService
                             .cancelHtsUserReminders(cancelHtsUserReminder)
-                            .fold(
-                              htsservError => {
-                                logger.warn(
-                                  s"An error occurred while accessing HTS Reminder service for user: ${htsContext.nino} Error: $htsservError"
-                                )
-                                internalServerError()
-                              },
-                              _ => SeeOther(routes.ReminderController.getRendersCancelConfirmPage.url)
+                            .value
+                            .flatMap(
+                              _.fold[Future[Result]](
+                                htsservError => {
+                                  logger.warn(
+                                    s"An error occurred while accessing HTS Reminder service for user: ${htsContext.nino} Error: $htsservError"
+                                  )
+                                  internalServerError()
+                                },
+                                _ => toFuture(SeeOther(routes.ReminderController.getRendersCancelConfirmPage.url))
+                              )
                             )
 
                         } else {
@@ -387,23 +404,28 @@ class ReminderController @Inject() (
                           )
                           helpToSaveReminderService
                             .updateHtsUser(htsUserToBeUpdated)
-                            .fold(
-                              htsError => {
-                                logger.warn(
-                                  s"An error occurred while accessing HTS Reminder service for user: ${userInfo.nino} Error: $htsError"
-                                )
-                                internalServerError()
-                              },
-                              htsUser =>
-                                SeeOther(
-                                  routes.ReminderController
-                                    .getRendersConfirmPage(
-                                      crypto.encrypt(htsUser.email),
-                                      success.reminderFrequency,
-                                      "Update"
+                            .value
+                            .flatMap(
+                              _.fold[Future[Result]](
+                                htsError => {
+                                  logger.warn(
+                                    s"An error occurred while accessing HTS Reminder service for user: ${userInfo.nino} Error: $htsError"
+                                  )
+                                  internalServerError()
+                                },
+                                htsUser =>
+                                  toFuture(
+                                    SeeOther(
+                                      routes.ReminderController
+                                        .getRendersConfirmPage(
+                                          crypto.encrypt(htsUser.email),
+                                          success.reminderFrequency,
+                                          "Update"
+                                        )
+                                        .url
                                     )
-                                    .url
-                                )
+                                  )
+                              )
                             )
                         }
                       }
@@ -461,24 +483,31 @@ class ReminderController @Inject() (
                       hasSelectedReminder = false
                     )
                   )
-                  .fold(
-                    _ => {
-                      internalServerError()
-                    },
-                    if (s.changingDetails) { _ =>
-                      SeeOther(routes.RegisterController.getCreateAccountPage.url)
-                    } else { _ =>
-                      SeeOther(routes.BankAccountController.getBankDetailsPage.url)
-                    }
+                  .value
+                  .flatMap(
+                    _.fold[Future[Result]](
+                      _ => {
+                        internalServerError()
+                      },
+                      _ =>
+                        if (s.changingDetails) {
+                          toFuture(SeeOther(routes.RegisterController.getCreateAccountPage.url))
+                        } else {
+                          toFuture(SeeOther(routes.BankAccountController.getBankDetailsPage.url))
+                        }
+                    )
                   )
               } else {
                 sessionStore
                   .store(s.copy(reminderValue = Some(success.reminderFrequency), hasSelectedReminder = true))
-                  .fold(
-                    _ => {
-                      internalServerError()
-                    },
-                    _ => SeeOther(routes.ReminderController.getApplySavingsReminderSignUpPage.url)
+                  .value
+                  .flatMap(
+                    _.fold[Future[Result]](
+                      _ => {
+                        internalServerError()
+                      },
+                      _ => toFuture(SeeOther(routes.ReminderController.getApplySavingsReminderSignUpPage.url))
+                    )
                   )
 
               }
@@ -544,15 +573,19 @@ class ReminderController @Inject() (
                   } else {
                     session.copy(reminderDetails = Some(success.reminderFrequency))
                   })
-                  .fold(
-                    _ => {
-                      internalServerError()
-                    },
-                    if (session.changingDetails) { _ =>
-                      SeeOther(routes.RegisterController.getCreateAccountPage.url)
-                    } else { _ =>
-                      SeeOther(routes.BankAccountController.getBankDetailsPage.url)
-                    }
+                  .value
+                  .flatMap(
+                    _.fold[Future[Result]](
+                      _ => {
+                        internalServerError()
+                      },
+                      _ =>
+                        if (session.changingDetails) {
+                          toFuture(SeeOther(routes.RegisterController.getCreateAccountPage.url))
+                        } else {
+                          toFuture(SeeOther(routes.BankAccountController.getBankDetailsPage.url))
+                        }
+                    )
                   )
               } else {
                 internalServerError()

--- a/app/uk/gov/hmrc/helptosavefrontend/controllers/SessionBehaviour.scala
+++ b/app/uk/gov/hmrc/helptosavefrontend/controllers/SessionBehaviour.scala
@@ -41,13 +41,12 @@ trait SessionBehaviour {
     transformer: NINOLogMessageTransformer,
     ec: ExecutionContext
   ): Future[Result] =
-    sessionStore.get
-      .semiflatMap(_.fold(noSession)(whenSession))
-      .leftMap { e =>
-        logger.warn(s"Could not read sessions data from mongo due to : $e", htsContext.nino)
-        internalServerError()
-      }
-      .merge
+    mergeWithInternalServerError(
+      sessionStore.get
+        .semiflatMap(_.fold(noSession)(whenSession))
+    )(
+      e => logger.warn(s"Could not read sessions data from mongo due to : $e", htsContext.nino)
+    )
 }
 
 object SessionBehaviour {

--- a/app/uk/gov/hmrc/helptosavefrontend/views/core/error_template.scala.html
+++ b/app/uk/gov/hmrc/helptosavefrontend/views/core/error_template.scala.html
@@ -18,7 +18,7 @@
 
 @this(layout: uk.gov.hmrc.helptosavefrontend.views.html.layout)
 
-@(pageTitle: String, heading: String, message: String)(implicit request: Request[_], messages: Messages, htsContext: HtsContext)
+@(pageTitle: String, heading: String, message: String)(implicit request: RequestHeader, messages: Messages, htsContext: HtsContext)
 
 @layout(pageTitle){
  <h1 class="govuk-heading-l">@heading</h1>

--- a/app/uk/gov/hmrc/helptosavefrontend/views/layout.scala.html
+++ b/app/uk/gov/hmrc/helptosavefrontend/views/layout.scala.html
@@ -40,7 +40,7 @@
   enableSignOutLink: Boolean = true,
   extraMeta: Option[Html] = None,
   beforeContent: Option[Html] = None
-)(contentBlock: Html)(implicit htsContext: HtsContext, request : Request[_], messages: Messages)
+)(contentBlock: Html)(implicit htsContext: HtsContext, request: RequestHeader, messages: Messages)
 
 @serviceName = @{messages("hts.global.title-suffix")}
 

--- a/test/uk/gov/hmrc/helptosavefrontend/controllers/ControllerSpecWithGuiceApp.scala
+++ b/test/uk/gov/hmrc/helptosavefrontend/controllers/ControllerSpecWithGuiceApp.scala
@@ -33,6 +33,7 @@ import uk.gov.hmrc.helptosavefrontend.util._
 import uk.gov.hmrc.http.{HeaderCarrier, SessionId}
 
 import java.util.UUID
+import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
@@ -79,7 +80,7 @@ trait ControllerSpecWithGuiceApp extends ControllerSpecBase with GuiceOneAppPerS
   val csrfAddToken: CSRFAddToken = injector.instanceOf[play.filters.csrf.CSRFAddToken]
 
   private lazy val technicalErrorPageContent: String =
-    injector.instanceOf[ErrorHandler].internalServerErrorTemplate(FakeRequest()).body
+    Await.result(injector.instanceOf[ErrorHandler].internalServerErrorTemplate(FakeRequest()), 5.seconds).body
 
   def checkIsTechnicalErrorPage(result: Future[Result]): Unit = {
     implicit val timeout: Timeout = Timeout(5 seconds)


### PR DESCRIPTION
- Address warning with legacy error handler
- Consolidate error handling in few helper functions to reduce the impact over all controllers

** NOTE **
There is an AT test that's failing consistently on both this branch and main. Will be addressing that, if any issues, before merge. It seems to be due to data and clear of mongo collection might resolve it but want it to be deterministic.