### PR TITLE
DLS-13239:HTS - Page title and heading mismatch: usability

### DIFF
--- a/app/uk/gov/hmrc/helptosavefrontend/views/helpinformation/help_information.scala.html
+++ b/app/uk/gov/hmrc/helptosavefrontend/views/helpinformation/help_information.scala.html
@@ -29,7 +29,7 @@
     Messages("hts.help.information.title.h1")
 }
 
-@layout(title = title + " " + Messages("hts.global.accountholder.title-suffix"), Some(appConfig.nsiManageAccountUrl)) {
+@layout(title, Some(appConfig.nsiManageAccountUrl)) {
     <h1 class="govuk-heading-l">@title</h1>
 
     <h2 class="govuk-heading-m">@messages("hts.help.information.h2")</h2>


### PR DESCRIPTION
<img width="665" height="481" alt="Screenshot from 2026-07-22 14-57-10" src="https://github.com/user-attachments/assets/f8eddc90-eb92-4fda-80ad-6276b553f630" />
